### PR TITLE
payment templates

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -104,12 +104,15 @@ function generateMonitoriEN(cb) {
  */
 function generateTemplates(cb, lang = 'FI', files = [], service = 'varaamo') {
     const {LOGO_URLS, LOGO_ALTS, FEEDBACK_URLS, MAP_URLS, FILE_PATH} = FILES;
+    const {PAYMENT} = FILE_PATH.VARAAMO;
 
     files.forEach((fileName) => {
         const lowerCaseLang = lang.toLowerCase();
         const upperCaseService = service.toUpperCase();
         // found in pages/template/footer/
         const footerName = `${lowerCaseLang}-varaamo.html`;
+        // found in pages/varaamo/payment
+        const paymentDetails = `${lowerCaseLang}-payment_details.html`;
         return gulp.src('./pages/template/index.html')
             .pipe(inject(gulp.src(`./pages/${service}/${lowerCaseLang}/${fileName}`), { // inject primary html content into index.html
                 starttag:  '<!-- inject:main:html -->',
@@ -130,6 +133,14 @@ function generateTemplates(cb, lang = 'FI', files = [], service = 'varaamo') {
                 quiet: true,
             }))
             .pipe(replace(FEEDBACK_URLS.SRC,FEEDBACK_URLS[lang])) // replace feedback url placeholder
+            .pipe(inject(gulp.src(`${PAYMENT.ROOT}${paymentDetails}`), { // inject order/payment details html
+                starttag:  '<!-- inject:order:html -->',
+                transform: function (filePath, file) {
+                    return file.contents.toString('utf8')
+                },
+                removeTags: true,
+                quiet: true,
+            }))
             .pipe(replace(MAP_URLS.SERVICE_MAP.SRC, MAP_URLS.SERVICE_MAP[lang])) // replace map url placeholder
             .pipe(inlineCss({
                 url: 'file://' + __dirname + '/pages/template/', // specifies the base path for the stylesheet links

--- a/pages/varaamo/en/en-reservation_created.html
+++ b/pages/varaamo/en/en-reservation_created.html
@@ -25,4 +25,10 @@
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
+{% if order is defined %}
+<hr />
+<!--inject:order:html-->
+<!-- endinject -->
+<hr />
+{% endif %}
 <p>Best regards, Varaamo</p>

--- a/pages/varaamo/fi/fi-reservation_created.html
+++ b/pages/varaamo/fi/fi-reservation_created.html
@@ -28,4 +28,10 @@
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
+{% if order is defined %}
+<hr />
+<!--inject:order:html-->
+<!-- endinject -->
+<hr />
+{% endif %}
 <p>Ystävällisin terveisin, Varaamo</p>

--- a/pages/varaamo/payment/en-payment_details.html
+++ b/pages/varaamo/payment/en-payment_details.html
@@ -16,7 +16,7 @@
                 </div>
             </td>
             <td>
-                {{ order[0].created_at }}
+                {{ order_details[0].created_at }}
             </td>
         </tr>
         </tbody>
@@ -34,7 +34,7 @@
                     </thead>
                     <tbody>
                     <tr>
-                        <td>{{ order[0].order_number }}</td>
+                        <td>{{ order_details[0].order_number }}</td>
                     </tr>
                     </tbody>
                 </table>
@@ -46,7 +46,7 @@
                     </thead>
                     <tbody>
                     <tr>
-                        <td>{{ order[0].id }}</td>
+                        <td>{{ order_details[0].id }}</td>
                     </tr>
                     </tbody>
                 </table>
@@ -87,7 +87,7 @@
         </tr>
         </thead>
         <tbody>
-        {% for value in order %}
+        {% for value in order_details %}
 
         <tr>
             <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
@@ -107,11 +107,11 @@
     <tbody>
     <tr>
         <td style="text-align: right;padding:5px;font-weight: bold">Subtotal</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order|sum(attribute='unit_price_num') }}€</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order_details|sum(attribute='unit_price_num') }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Total(incl. VAT. {{ order[0].tax_percentage }}%)</td>
-        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order|sum(attribute='unit_price_num') }}€</td>
+        <td style="text-align: right;padding:5px;font-weight: bold">Total(incl. VAT. {{ order_details[0].tax_percentage }}%)</td>
+        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order_details|sum(attribute='unit_price_num') }}€</td>
     </tr>
     </tbody>
 </table>

--- a/pages/varaamo/payment/en-payment_details.html
+++ b/pages/varaamo/payment/en-payment_details.html
@@ -1,0 +1,117 @@
+<div style="padding: 0 0 0 0">
+    <table>
+        <thead>
+        <tr>
+            <th style="font-weight: bold; width: 50%">Purchaser's details</th>
+            <th style="font-weight: bold;width: 50%">Date of issue</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <div>
+                    <p style="margin-bottom: 0">{{ billing_first_name }} {{ billing_last_name }}</p>
+                    <p style="margin-bottom: 0">{{ billing_address_street }}</p>
+                    <p style="margin-bottom: 0">{{ billing_address_zip }} {{ billing_address_city }}</p>
+                </div>
+            </td>
+            <td>
+                {{ order[0].created_at }}
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<div style="padding-top: 20px;">
+    <table>
+        <tr>
+            <td style="width: 50%">
+                <table>
+                    <thead>
+                    <tr>
+                        <th style="font-weight: bold">Order number</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>{{ order[0].order_number }}</td>
+                    </tr>
+                    </tbody>
+                </table>
+                <table>
+                    <thead>
+                    <tr>
+                        <th style="font-weight: bold;padding-top: 10px">Transaction number</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>{{ order[0].id }}</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </td>
+            <td style="width: 50%">
+                <table>
+                    <thead>
+                    <tr>
+                        <th style="font-weight: bold">Seller's details</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>
+                            <div>
+                                <p style="margin-bottom: 0">City of Turku</p>
+                                <p style="margin-bottom: 0">PO 355</p>
+                                <p style="margin-bottom: 0">20101 TURKU</p>
+                                <p style="margin-bottom: 0">Business ID 0204819-8</p>
+                            </div>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </table>
+</div>
+
+<div style="padding: 20px 0">
+    <table>
+        <thead>
+        <tr style="border: 1px solid">
+            <th style="padding:5px">Description</th>
+            <th style="padding:5px">Unit price</th>
+            <th style="padding:5px">Quantity</th>
+            <th style="padding:5px;text-align: center">Subtotal</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for value in order %}
+
+        <tr>
+            <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
+            {% if value.price_type == 'fixed' %}
+            <td style="text-align: left;padding:5px">{{ value.price }}€</td>
+            {% else %}
+            <td style="text-align: left;padding:5px">{{ value.price }}€ / {{ value.decimal_hours}}h</td>
+            {% endif %}
+            <td style="text-align: left;padding:5px">{{ value.quantity }}</td>
+            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.unit_price }}€</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+<table>
+    <tbody>
+    <tr>
+        <td style="text-align: right;padding:5px;font-weight: bold">Subtotal</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order|sum(attribute='unit_price_num') }}€</td>
+    </tr>
+    <tr>
+        <td style="text-align: right;padding:5px;font-weight: bold">Total(incl. VAT. {{ order[0].tax_percentage }}%)</td>
+        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order|sum(attribute='unit_price_num') }}€</td>
+    </tr>
+    </tbody>
+</table>

--- a/pages/varaamo/payment/fi-payment_details.html
+++ b/pages/varaamo/payment/fi-payment_details.html
@@ -16,7 +16,7 @@
                 </div>
             </td>
             <td>
-                {{ order[0].created_at }}
+                {{ order_details[0].created_at }}
             </td>
         </tr>
         </tbody>
@@ -34,7 +34,7 @@
                     </thead>
                     <tbody>
                     <tr>
-                        <td>{{ order[0].order_number }}</td>
+                        <td>{{ order_details[0].order_number }}</td>
                     </tr>
                     </tbody>
                 </table>
@@ -46,7 +46,7 @@
                     </thead>
                     <tbody>
                     <tr>
-                        <td>{{ order[0].id }}</td>
+                        <td>{{ order_details[0].id }}</td>
                     </tr>
                     </tbody>
                 </table>
@@ -87,7 +87,7 @@
         </tr>
         </thead>
         <tbody>
-        {% for value in order %}
+        {% for value in order_details %}
 
         <tr>
             <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
@@ -107,11 +107,11 @@
     <tbody>
     <tr>
         <td style="text-align: right;padding:5px;font-weight: bold">Yhteensä</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order|sum(attribute='unit_price_num') }}€</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order_details|sum(attribute='unit_price_num') }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Maksu(sis. alv. {{ order[0].tax_percentage }}%)</td>
-        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order|sum(attribute='unit_price_num') }}€</td>
+        <td style="text-align: right;padding:5px;font-weight: bold">Maksu(sis. alv. {{ order_details[0].tax_percentage }}%)</td>
+        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order_details|sum(attribute='unit_price_num') }}€</td>
     </tr>
     </tbody>
 </table>

--- a/pages/varaamo/payment/fi-payment_details.html
+++ b/pages/varaamo/payment/fi-payment_details.html
@@ -1,0 +1,117 @@
+<div style="padding: 0 0 0 0">
+    <table>
+        <thead>
+        <tr>
+            <th style="font-weight: bold; width: 50%">Maksajan tiedot</th>
+            <th style="font-weight: bold;width: 50%">Tapahtuman päivämäärä</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <div>
+                    <p style="margin-bottom: 0">{{ billing_first_name }} {{ billing_last_name }}</p>
+                    <p style="margin-bottom: 0">{{ billing_address_street }}</p>
+                    <p style="margin-bottom: 0">{{ billing_address_zip }} {{ billing_address_city }}</p>
+                </div>
+            </td>
+            <td>
+                {{ order[0].created_at }}
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<div style="padding-top: 20px;">
+    <table>
+        <tr>
+            <td style="width: 50%">
+                <table>
+                    <thead>
+                    <tr>
+                        <th style="font-weight: bold">Laskun tunniste</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>{{ order[0].order_number }}</td>
+                    </tr>
+                    </tbody>
+                </table>
+                <table>
+                    <thead>
+                    <tr>
+                        <th style="font-weight: bold;padding-top: 10px">Tapahtuman tunniste</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>{{ order[0].id }}</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </td>
+            <td style="width: 50%">
+                <table>
+                    <thead>
+                    <tr>
+                        <th style="font-weight: bold">Myyjän tiedot</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>
+                            <div>
+                                <p style="margin-bottom: 0">Turun Kaupunki</p>
+                                <p style="margin-bottom: 0">PL 355</p>
+                                <p style="margin-bottom: 0">20101 TURKU</p>
+                                <p style="margin-bottom: 0">Y-tunnus 0204819-8</p>
+                            </div>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </table>
+</div>
+
+<div style="padding: 20px 0">
+    <table>
+        <thead>
+        <tr style="border: 1px solid">
+            <th style="padding:5px">Kuvaus</th>
+            <th style="padding:5px">Yksikköhinta</th>
+            <th style="padding:5px">Määrä</th>
+            <th style="padding:5px;text-align: center">Summa</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for value in order %}
+
+        <tr>
+            <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
+            {% if value.price_type == 'fixed' %}
+            <td style="text-align: left;padding:5px">{{ value.price }}€</td>
+            {% else %}
+            <td style="text-align: left;padding:5px">{{ value.price }}€ / {{ value.decimal_hours}} tuntia</td>
+            {% endif %}
+            <td style="text-align: left;padding:5px">{{ value.quantity }}</td>
+            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.unit_price }}€</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+<table>
+    <tbody>
+    <tr>
+        <td style="text-align: right;padding:5px;font-weight: bold">Yhteensä</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order|sum(attribute='unit_price_num') }}€</td>
+    </tr>
+    <tr>
+        <td style="text-align: right;padding:5px;font-weight: bold">Maksu(sis. alv. {{ order[0].tax_percentage }}%)</td>
+        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order|sum(attribute='unit_price_num') }}€</td>
+    </tr>
+    </tbody>
+</table>

--- a/pages/varaamo/payment/sv-payment_details.html
+++ b/pages/varaamo/payment/sv-payment_details.html
@@ -16,7 +16,7 @@
                 </div>
             </td>
             <td>
-                {{ order[0].created_at }}
+                {{ order_details[0].created_at }}
             </td>
         </tr>
         </tbody>
@@ -34,7 +34,7 @@
                     </thead>
                     <tbody>
                     <tr>
-                        <td>{{ order[0].order_number }}</td>
+                        <td>{{ order_details[0].order_number }}</td>
                     </tr>
                     </tbody>
                 </table>
@@ -46,7 +46,7 @@
                     </thead>
                     <tbody>
                     <tr>
-                        <td>{{ order[0].id }}</td>
+                        <td>{{ order_details[0].id }}</td>
                     </tr>
                     </tbody>
                 </table>
@@ -87,7 +87,7 @@
         </tr>
         </thead>
         <tbody>
-        {% for value in order %}
+        {% for value in order_details %}
 
         <tr>
             <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
@@ -107,11 +107,11 @@
     <tbody>
     <tr>
         <td style="text-align: right;padding:5px;font-weight: bold">Totalsumma</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order|sum(attribute='unit_price_num') }}€</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order_details|sum(attribute='unit_price_num') }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Slutsumma(inkl. moms {{ order[0].tax_percentage }}%)</td>
-        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order|sum(attribute='unit_price_num') }}€</td>
+        <td style="text-align: right;padding:5px;font-weight: bold">Slutsumma(inkl. moms {{ order_details[0].tax_percentage }}%)</td>
+        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order_details|sum(attribute='unit_price_num') }}€</td>
     </tr>
     </tbody>
 </table>

--- a/pages/varaamo/payment/sv-payment_details.html
+++ b/pages/varaamo/payment/sv-payment_details.html
@@ -1,0 +1,117 @@
+<div style="padding: 0 0 0 0">
+    <table>
+        <thead>
+        <tr>
+            <th style="font-weight: bold; width: 50%">Köparens uppgifter</th>
+            <th style="font-weight: bold;width: 50%">Fakturans datum</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <div>
+                    <p style="margin-bottom: 0">{{ billing_first_name }} {{ billing_last_name }}</p>
+                    <p style="margin-bottom: 0">{{ billing_address_street }}</p>
+                    <p style="margin-bottom: 0">{{ billing_address_zip }} {{ billing_address_city }}</p>
+                </div>
+            </td>
+            <td>
+                {{ order[0].created_at }}
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<div style="padding-top: 20px;">
+    <table>
+        <tr>
+            <td style="width: 50%">
+                <table>
+                    <thead>
+                    <tr>
+                        <th style="font-weight: bold">Fakturanummer</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>{{ order[0].order_number }}</td>
+                    </tr>
+                    </tbody>
+                </table>
+                <table>
+                    <thead>
+                    <tr>
+                        <th style="font-weight: bold;padding-top: 10px">Händelsenummer</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>{{ order[0].id }}</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </td>
+            <td style="width: 50%">
+                <table>
+                    <thead>
+                    <tr>
+                        <th style="font-weight: bold">Säljarens uppgifter</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>
+                            <div>
+                                <p style="margin-bottom: 0">Åbo Stad</p>
+                                <p style="margin-bottom: 0">PO 355</p>
+                                <p style="margin-bottom: 0">20101 ÅBO</p>
+                                <p style="margin-bottom: 0">FO-nummer 0204819-8</p>
+                            </div>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </table>
+</div>
+
+<div style="padding: 20px 0">
+    <table>
+        <thead>
+        <tr style="border: 1px solid">
+            <th style="padding:5px">Beskrivning</th>
+            <th style="padding:5px">Enhetspris</th>
+            <th style="padding:5px">Mängd</th>
+            <th style="padding:5px;text-align: center">Summa</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for value in order %}
+
+        <tr>
+            <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
+            {% if value.price_type == 'fixed' %}
+            <td style="text-align: left;padding:5px">{{ value.price }}€</td>
+            {% else %}
+            <td style="text-align: left;padding:5px">{{ value.price }}€ / {{ value.decimal_hours}} timmar</td>
+            {% endif %}
+            <td style="text-align: left;padding:5px">{{ value.quantity }}</td>
+            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.unit_price }}€</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+<table>
+    <tbody>
+    <tr>
+        <td style="text-align: right;padding:5px;font-weight: bold">Totalsumma</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order|sum(attribute='unit_price_num') }}€</td>
+    </tr>
+    <tr>
+        <td style="text-align: right;padding:5px;font-weight: bold">Slutsumma(inkl. moms {{ order[0].tax_percentage }}%)</td>
+        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order|sum(attribute='unit_price_num') }}€</td>
+    </tr>
+    </tbody>
+</table>

--- a/pages/varaamo/sv/sv-reservation_created.html
+++ b/pages/varaamo/sv/sv-reservation_created.html
@@ -26,7 +26,9 @@
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 {% if order is defined %}
+<hr />
 <!--inject:order:html-->
 <!-- endinject -->
+<hr />
 {% endif %}
 <p>Med vänliga hälsningar, Varaamo</p>

--- a/pages/varaamo/sv/sv-reservation_created.html
+++ b/pages/varaamo/sv/sv-reservation_created.html
@@ -25,4 +25,8 @@
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
+{% if order is defined %}
+<!--inject:order:html-->
+<!-- endinject -->
+{% endif %}
 <p>Med vänliga hälsningar, Varaamo</p>

--- a/variables.js
+++ b/variables.js
@@ -14,12 +14,13 @@
 
 /**
  * @typedef ServiceSpecificObject
- * Contains language specific objects
+ * Contains language specific objects + additional keys
  * @see {@link LanguageSpecificObject} example of a language specific object
  * @example
  * FI:{},
  * SV:{},
  * EN:{}
+ * PAYMENT:{}
  */
 
 /**
@@ -66,6 +67,9 @@ export default {
                 DEST: 'build/varaamo/en/',
                 ROOT: '/pages/varaamo/en/'
             },
+            PAYMENT: {
+                ROOT: './pages/varaamo/payment/',
+            }
         },
 
         /** @see {@link ServiceSpecificObject} **/


### PR DESCRIPTION
Added new payment template partials that can be injected into other templates, initially only added to varaamo-specific reservation_created templates.

Add
 `<!--inject:order:html-->`
`<!-- endinject -->`

into a templates html in order to inject the payment html when building the template. See varaamo reservation_created.html files for actual implementation.