### PR TITLE
payment details change

### DIFF
--- a/pages/monitori/en/en-reservation_created.html
+++ b/pages/monitori/en/en-reservation_created.html
@@ -22,7 +22,7 @@
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
 <p>Once you arrive at Monitori Market Square, please check in at the queue number machine with the phone number that you used to create the reservation.</p>

--- a/pages/monitori/en/en-reservation_created_by_official_client.html
+++ b/pages/monitori/en/en-reservation_created_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
 <p>Once you arrive at Monitori Market Square, please check in at the queue number machine with the phone number that you used to create the reservation.</p>

--- a/pages/monitori/en/en-reservation_modified.html
+++ b/pages/monitori/en/en-reservation_modified.html
@@ -22,7 +22,7 @@
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
 <p>Once you arrive at Monitori Market Square, please check in at the queue number machine with the phone number that you used to create the reservation.</p>

--- a/pages/monitori/en/en-reservation_modified_by_official_client.html
+++ b/pages/monitori/en/en-reservation_modified_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
 <p>Once you arrive at Monitori Market Square, please check in at the queue number machine with the phone number that you used to create the reservation.</p>

--- a/pages/monitori/fi/fi-reservation_created.html
+++ b/pages/monitori/fi/fi-reservation_created.html
@@ -22,7 +22,7 @@
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
 <p>Tullessasi Kauppatorin Monitoriin ilmoittaudu kaupungin vuoronumerolaitteella käyttämällä tässä varauksessa antamaasi puhelinnumeroa.</p>

--- a/pages/monitori/fi/fi-reservation_created_by_official_client.html
+++ b/pages/monitori/fi/fi-reservation_created_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
 <p>Tullessasi Kauppatorin Monitoriin ilmoittaudu kaupungin vuoronumerolaitteella käyttämällä tässä varauksessa antamaasi puhelinnumeroa.</p>

--- a/pages/monitori/fi/fi-reservation_modified.html
+++ b/pages/monitori/fi/fi-reservation_modified.html
@@ -21,7 +21,7 @@
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
 <p>Tullessasi Kauppatorin Monitoriin ilmoittaudu kaupungin vuoronumerolaitteella käyttämällä tässä varauksessa antamaasi puhelinnumeroa.</p>

--- a/pages/monitori/fi/fi-reservation_modified_by_official_client.html
+++ b/pages/monitori/fi/fi-reservation_modified_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
 <p>Tullessasi Kauppatorin Monitoriin ilmoittaudu kaupungin vuoronumerolaitteella käyttämällä tässä varauksessa antamaasi puhelinnumeroa.</p>

--- a/pages/monitori/sv/sv-reservation_created.html
+++ b/pages/monitori/sv/sv-reservation_created.html
@@ -1,6 +1,6 @@
 <p>Hej,</p>
 <p>tack för din bokning. Den är nu bekräftad.</p>
-<p>Här är bokningens information:</p>
+<p>Här är bokningsuppgifterna:</p>
 <hr />
 <p>Utrymme: {{ resource }}</p>
 <p>Plats: {{ unit }}</p>
@@ -22,7 +22,7 @@
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 <p>När du kommer till Salutorgets Monitori skall du anmäla dig vid stadens könummerautomat med det telefonnummer som du gav i bokningen.</p>

--- a/pages/monitori/sv/sv-reservation_created_by_official_client.html
+++ b/pages/monitori/sv/sv-reservation_created_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 <p>När du kommer till Salutorgets Monitori skall du anmäla dig vid stadens könummerautomat med det telefonnummer som du gav i bokningen.</p>

--- a/pages/monitori/sv/sv-reservation_modified.html
+++ b/pages/monitori/sv/sv-reservation_modified.html
@@ -1,6 +1,6 @@
 <p>Hej,</p>
 <p>Du har gjort ändringar i din bokning.</p>
-<p>Här är bokningens uppdaterade information:</p>
+<p>Här är uppdaterade bokningsuppgifterna:</p>
 <hr />
 <p>Utrymme: {{ resource }}</p>
 <p>Plats: {{ unit }}</p>
@@ -22,7 +22,7 @@
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 <p>När du kommer till Salutorgets Monitori skall du anmäla dig vid stadens könummerautomat med det telefonnummer som du gav i bokningen.</p>

--- a/pages/monitori/sv/sv-reservation_modified_by_official_client.html
+++ b/pages/monitori/sv/sv-reservation_modified_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 <p>När du kommer till Salutorgets Monitori skall du anmäla dig vid stadens könummerautomat med det telefonnummer som du gav i bokningen.</p>

--- a/pages/varaamo/en/en-recurring_reservation_created.html
+++ b/pages/varaamo/en/en-recurring_reservation_created.html
@@ -26,7 +26,7 @@
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
 <p>Best regards, Varaamo</p>

--- a/pages/varaamo/en/en-reservation_cancelled_by_official_client.html
+++ b/pages/varaamo/en/en-reservation_cancelled_by_official_client.html
@@ -21,7 +21,7 @@
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
 <p>Best regards, Varaamo</p>

--- a/pages/varaamo/en/en-reservation_created.html
+++ b/pages/varaamo/en/en-reservation_created.html
@@ -22,7 +22,7 @@
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
 {% if order is defined %}

--- a/pages/varaamo/en/en-reservation_created_by_official_client.html
+++ b/pages/varaamo/en/en-reservation_created_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
 <p>Best regards, Varaamo</p>

--- a/pages/varaamo/en/en-reservation_modified.html
+++ b/pages/varaamo/en/en-reservation_modified.html
@@ -22,7 +22,7 @@
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
 <p>Best regards, Varaamo</p>

--- a/pages/varaamo/en/en-reservation_modified_by_official_client.html
+++ b/pages/varaamo/en/en-reservation_modified_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}
 <p>Best regards, Varaamo</p>

--- a/pages/varaamo/fi/fi-recurring_reservation_created.html
+++ b/pages/varaamo/fi/fi-recurring_reservation_created.html
@@ -29,7 +29,7 @@
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
 <p>Ystävällisin terveisin, Varaamo</p>

--- a/pages/varaamo/fi/fi-reservation_cancelled_by_official_client.html
+++ b/pages/varaamo/fi/fi-reservation_cancelled_by_official_client.html
@@ -21,7 +21,7 @@
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
 <p>Tervetuloa asioimaan uudelleen!</p>

--- a/pages/varaamo/fi/fi-reservation_created.html
+++ b/pages/varaamo/fi/fi-reservation_created.html
@@ -25,7 +25,7 @@
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
 {% if order is defined %}

--- a/pages/varaamo/fi/fi-reservation_created_by_official_client.html
+++ b/pages/varaamo/fi/fi-reservation_created_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
 <p>Ystävällisin terveisin, Varaamo</p>

--- a/pages/varaamo/fi/fi-reservation_modified.html
+++ b/pages/varaamo/fi/fi-reservation_modified.html
@@ -21,7 +21,7 @@
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
 <p>Ystävällisin terveisin, Varaamo</p>

--- a/pages/varaamo/fi/fi-reservation_modified_by_official_client.html
+++ b/pages/varaamo/fi/fi-reservation_modified_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}
 <p>Ystävällisin terveisin, Varaamo</p>

--- a/pages/varaamo/payment/en-payment_details.html
+++ b/pages/varaamo/payment/en-payment_details.html
@@ -80,10 +80,11 @@
     <table>
         <thead>
         <tr style="border: 1px solid">
-            <th style="padding:5px">Description</th>
-            <th style="padding:5px">Unit price</th>
+            <th style="padding:5px">Product/service</th>
             <th style="padding:5px">Quantity</th>
-            <th style="padding:5px;text-align: center">Subtotal</th>
+            <th style="padding:5px">Tax-free price</th>
+            <th style="padding:5px">VAT %</th>
+            <th style="padding:5px;text-align: center">Total tax-free price</th>
         </tr>
         </thead>
         <tbody>
@@ -91,13 +92,10 @@
 
         <tr>
             <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
-            {% if value.price_type == 'fixed' %}
-            <td style="text-align: left;padding:5px">{{ value.price }}€</td>
-            {% else %}
-            <td style="text-align: left;padding:5px">{{ value.price }}€ / {{ value.decimal_hours}}h</td>
-            {% endif %}
             <td style="text-align: left;padding:5px">{{ value.quantity }}</td>
-            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.unit_price }}€</td>
+            <td style="text-align: left;padding:5px">{{ value.pretax_price }}</td>
+            <td style="text-align: left;padding:5px">{{ value.tax_percentage }}</td>
+            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.pretax_price }}</td>
         </tr>
         {% endfor %}
         </tbody>
@@ -106,12 +104,16 @@
 <table>
     <tbody>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Subtotal</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order_details|sum(attribute='unit_price_num') }}€</td>
+        <td style="text-align: right;padding:5px;font-weight: bold">Tax-free price total</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format((order_details|sum(attribute='pretax_price_num') * order_details[0].quantity)|round(2))  }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Total(incl. VAT. {{ order_details[0].tax_percentage }}%)</td>
-        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order_details|sum(attribute='unit_price_num') }}€</td>
+        <td style="text-align: right;padding:5px;font-weight: bold">VAT {{ order_details[0].tax_percentage }} total</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format( (order_details|sum(attribute='tax_price_num') * order_details[0].quantity)|round(2)) }}€</td>
+    </tr>
+    <tr>
+        <td style="text-align: right;padding:5px;font-weight: bold">Total</td>
+        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ "%.2f"|format(order_details|sum(attribute='unit_price_num')) }}€</td>
     </tr>
     </tbody>
 </table>

--- a/pages/varaamo/payment/fi-payment_details.html
+++ b/pages/varaamo/payment/fi-payment_details.html
@@ -80,10 +80,11 @@
     <table>
         <thead>
         <tr style="border: 1px solid">
-            <th style="padding:5px">Kuvaus</th>
-            <th style="padding:5px">Yksikköhinta</th>
+            <th style="padding:5px">Tuote/palvelu</th>
             <th style="padding:5px">Määrä</th>
-            <th style="padding:5px;text-align: center">Summa</th>
+            <th style="padding:5px">Veroton hinta</th>
+            <th style="padding:5px">Alv %</th>
+            <th style="padding:5px;text-align: center">Veroton yhteensä</th>
         </tr>
         </thead>
         <tbody>
@@ -91,13 +92,10 @@
 
         <tr>
             <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
-            {% if value.price_type == 'fixed' %}
-            <td style="text-align: left;padding:5px">{{ value.price }}€</td>
-            {% else %}
-            <td style="text-align: left;padding:5px">{{ value.price }}€ / {{ value.decimal_hours}} tuntia</td>
-            {% endif %}
             <td style="text-align: left;padding:5px">{{ value.quantity }}</td>
-            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.unit_price }}€</td>
+            <td style="text-align: left;padding:5px">{{ value.pretax_price }}</td>
+            <td style="text-align: left;padding:5px">{{ value.tax_percentage }}</td>
+            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.pretax_price }}</td>
         </tr>
         {% endfor %}
         </tbody>
@@ -106,12 +104,16 @@
 <table>
     <tbody>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Yhteensä</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order_details|sum(attribute='unit_price_num') }}€</td>
+        <td style="text-align: right;padding:5px;font-weight: bold">Veroton hinta yhteensä</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format((order_details|sum(attribute='pretax_price_num') * order_details[0].quantity)|round(2))  }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Maksu(sis. alv. {{ order_details[0].tax_percentage }}%)</td>
-        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order_details|sum(attribute='unit_price_num') }}€</td>
+        <td style="text-align: right;padding:5px;font-weight: bold">ALV {{ order_details[0].tax_percentage }} yhteensä</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format( (order_details|sum(attribute='tax_price_num') * order_details[0].quantity)|round(2)) }}€</td>
+    </tr>
+    <tr>
+        <td style="text-align: right;padding:5px;font-weight: bold">Lasku yhteensä</td>
+        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ "%.2f"|format(order_details|sum(attribute='unit_price_num')) }}€</td>
     </tr>
     </tbody>
 </table>

--- a/pages/varaamo/payment/sv-payment_details.html
+++ b/pages/varaamo/payment/sv-payment_details.html
@@ -80,10 +80,11 @@
     <table>
         <thead>
         <tr style="border: 1px solid">
-            <th style="padding:5px">Beskrivning</th>
-            <th style="padding:5px">Enhetspris</th>
+            <th style="padding:5px">Produkt/service</th>
             <th style="padding:5px">Mängd</th>
-            <th style="padding:5px;text-align: center">Summa</th>
+            <th style="padding:5px">Skattefritt pris</th>
+            <th style="padding:5px">Moms %</th>
+            <th style="padding:5px;text-align: center">Totala skattefria</th>
         </tr>
         </thead>
         <tbody>
@@ -91,13 +92,10 @@
 
         <tr>
             <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
-            {% if value.price_type == 'fixed' %}
-            <td style="text-align: left;padding:5px">{{ value.price }}€</td>
-            {% else %}
-            <td style="text-align: left;padding:5px">{{ value.price }}€ / {{ value.decimal_hours}} timmar</td>
-            {% endif %}
             <td style="text-align: left;padding:5px">{{ value.quantity }}</td>
-            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.unit_price }}€</td>
+            <td style="text-align: left;padding:5px">{{ value.pretax_price }}</td>
+            <td style="text-align: left;padding:5px">{{ value.tax_percentage }}</td>
+            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.pretax_price }}</td>
         </tr>
         {% endfor %}
         </tbody>
@@ -106,12 +104,16 @@
 <table>
     <tbody>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Totalsumma</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ order_details|sum(attribute='unit_price_num') }}€</td>
+        <td style="text-align: right;padding:5px;font-weight: bold">Totala skattefria priset</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format((order_details|sum(attribute='pretax_price_num') * order_details[0].quantity)|round(2))  }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Slutsumma(inkl. moms {{ order_details[0].tax_percentage }}%)</td>
-        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ order_details|sum(attribute='unit_price_num') }}€</td>
+        <td style="text-align: right;padding:5px;font-weight: bold">Moms {{ order_details[0].tax_percentage }} totalt</td>
+        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format( (order_details|sum(attribute='tax_price_num') * order_details[0].quantity)|round(2)) }}€</td>
+    </tr>
+    <tr>
+        <td style="text-align: right;padding:5px;font-weight: bold">Totala priset</td>
+        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ "%.2f"|format(order_details|sum(attribute='unit_price_num')) }}€</td>
     </tr>
     </tbody>
 </table>

--- a/pages/varaamo/sv/sv-recurring_reservation_created.html
+++ b/pages/varaamo/sv/sv-recurring_reservation_created.html
@@ -29,7 +29,7 @@
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 <p>Med vänliga hälsningar, Varaamo</p>

--- a/pages/varaamo/sv/sv-reservation_cancelled_by_official_client.html
+++ b/pages/varaamo/sv/sv-reservation_cancelled_by_official_client.html
@@ -21,7 +21,7 @@
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 <p>Välkommen åter!</p>

--- a/pages/varaamo/sv/sv-reservation_created.html
+++ b/pages/varaamo/sv/sv-reservation_created.html
@@ -1,6 +1,6 @@
 <p>Hej,</p>
 <p>tack för din bokning. Den är nu bekräftad.</p>
-<p>Här är bokningens information:</p>
+<p>Här är bokningsuppgifterna:</p>
 <hr />
 <p>Utrymme: {{ resource }}</p>
 <p>Plats: {{ unit }}</p>
@@ -22,7 +22,7 @@
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 {% if order is defined %}

--- a/pages/varaamo/sv/sv-reservation_created_by_official_client.html
+++ b/pages/varaamo/sv/sv-reservation_created_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 <p>Med vänliga hälsningar, Varaamo</p>

--- a/pages/varaamo/sv/sv-reservation_modified.html
+++ b/pages/varaamo/sv/sv-reservation_modified.html
@@ -1,6 +1,6 @@
 <p>Hej,</p>
 <p>Du har gjort ändringar i din bokning.</p>
-<p>Här är bokningens uppdaterade information:</p>
+<p>Här är uppdaterade bokningsuppgifterna:</p>
 <hr />
 <p>Utrymme: {{ resource }}</p>
 <p>Plats: {{ unit }}</p>
@@ -22,7 +22,7 @@
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 <p>Med vänliga hälsningar, Varaamo</p>

--- a/pages/varaamo/sv/sv-reservation_modified_by_official_client.html
+++ b/pages/varaamo/sv/sv-reservation_modified_by_official_client.html
@@ -22,7 +22,7 @@
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
 {% if unit is defined %}
-{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#!route-details' %}
+{% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}
 <p>Med vänliga hälsningar, Varaamo</p>


### PR DESCRIPTION
Changes:
- Adjusted varaamo payment details layout to look similar to other turku bills. Prices are displayed with the same precision(2 decimal places) as the turku bills.

- Removed broken `!route-details` url param from the service map links as the service map doesn't work with it anymore.
- Minor change to the swedish templates wording.