### PR TITLE
payment details refactoring & changes

### DIFF
--- a/pages/css/turku-custom.css
+++ b/pages/css/turku-custom.css
@@ -37,3 +37,78 @@
 .copyright-text {
     margin: 0;
 }
+
+.billing-details {
+    padding: 0 0 0 0;
+
+}
+.billing-details-headers {
+    font-weight: bold;
+    width: 50%;
+}
+
+.billing-details-values,
+.payment-details-seller-values {
+    margin-bottom: 0;
+}
+
+.payment-details {
+    padding-top: 20px;
+}
+.payment-details-ids,
+.payment-details-seller {
+    width: 50%;
+}
+
+.payment-details-bill-id,
+.payment-details-seller-header{
+    font-weight: bold;
+}
+
+.payment-details-event-id {
+    font-weight: bold;
+    padding-top: 10px;
+}
+
+.order-details {
+    padding: 20px 0;
+}
+
+.order-details-headers-tr {
+    border: 1px solid #000000;
+}
+.order-details-headers {
+    padding: 5px;
+}
+
+.order-details-headers-last-value {
+    padding: 5px;
+    text-align: center;
+}
+
+.order-details-values-first {
+    padding: 5px;
+}
+.order-details-values-middle {
+    text-align: left;
+    padding: 5px;
+}
+.order-details-values-last-value {
+    text-align: right;
+    padding: 5px 35px 5px 5px;
+}
+
+.order-summary-headers {
+    text-align: right;
+    padding: 5px;
+    font-weight: bold;
+}
+.order-summary-values {
+    text-align: right;
+    padding: 5px 35px 5px 5px;
+}
+.order-summary-values-last-value {
+    text-align: right;
+    padding: 5px 35px 5px 5px;
+    width: 100px;
+}

--- a/pages/varaamo/payment/en-payment_details.html
+++ b/pages/varaamo/payment/en-payment_details.html
@@ -1,18 +1,18 @@
-<div style="padding: 0 0 0 0">
+<div class="billing-details">
     <table>
         <thead>
         <tr>
-            <th style="font-weight: bold; width: 50%">Purchaser's details</th>
-            <th style="font-weight: bold;width: 50%">Date of issue</th>
+            <th class="billing-details-headers">Purchaser's details</th>
+            <th class="billing-details-headers">Date of issue</th>
         </tr>
         </thead>
         <tbody>
         <tr>
             <td>
                 <div>
-                    <p style="margin-bottom: 0">{{ billing_first_name }} {{ billing_last_name }}</p>
-                    <p style="margin-bottom: 0">{{ billing_address_street }}</p>
-                    <p style="margin-bottom: 0">{{ billing_address_zip }} {{ billing_address_city }}</p>
+                    <p class="billing-details-values">{{ billing_first_name }} {{ billing_last_name }}</p>
+                    <p class="billing-details-values">{{ billing_address_street }}</p>
+                    <p class="billing-details-values">{{ billing_address_zip }} {{ billing_address_city }}</p>
                 </div>
             </td>
             <td>
@@ -22,14 +22,14 @@
         </tbody>
     </table>
 </div>
-<div style="padding-top: 20px;">
+<div class="payment-details">
     <table>
         <tr>
-            <td style="width: 50%">
+            <td class="payment-details-ids">
                 <table>
                     <thead>
                     <tr>
-                        <th style="font-weight: bold">Order number</th>
+                        <th class="payment-details-bill-id">Order number</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -41,7 +41,7 @@
                 <table>
                     <thead>
                     <tr>
-                        <th style="font-weight: bold;padding-top: 10px">Transaction number</th>
+                        <th class="payment-details-event-id">Transaction number</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -51,21 +51,21 @@
                     </tbody>
                 </table>
             </td>
-            <td style="width: 50%">
+            <td class="payment-details-seller">
                 <table>
                     <thead>
                     <tr>
-                        <th style="font-weight: bold">Seller's details</th>
+                        <th class="payment-details-seller-header">Seller's details</th>
                     </tr>
                     </thead>
                     <tbody>
                     <tr>
                         <td>
                             <div>
-                                <p style="margin-bottom: 0">City of Turku</p>
-                                <p style="margin-bottom: 0">PO 355</p>
-                                <p style="margin-bottom: 0">20101 TURKU</p>
-                                <p style="margin-bottom: 0">Business ID 0204819-8</p>
+                                <p class="payment-details-seller-values">City of Turku</p>
+                                <p class="payment-details-seller-values">PO 355</p>
+                                <p class="payment-details-seller-values">20101 TURKU</p>
+                                <p class="payment-details-seller-values">Business ID 0204819-8</p>
                             </div>
                         </td>
                     </tr>
@@ -76,26 +76,26 @@
     </table>
 </div>
 
-<div style="padding: 20px 0">
+<div class="order-details">
     <table>
         <thead>
-        <tr style="border: 1px solid">
-            <th style="padding:5px">Product/service</th>
-            <th style="padding:5px">Quantity</th>
-            <th style="padding:5px">Tax-free price</th>
-            <th style="padding:5px">VAT %</th>
-            <th style="padding:5px;text-align: center">Total tax-free price</th>
+        <tr class="order-details-headers-tr">
+            <th class="order-details-headers">Product/service</th>
+            <th class="order-details-headers">Quantity</th>
+            <th class="order-details-headers">Unit price</th>
+            <th class="order-details-headers">VAT %</th>
+            <th class="order-details-headers-last-value">Total tax-free price</th>
         </tr>
         </thead>
         <tbody>
         {% for value in order_details %}
 
         <tr>
-            <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
-            <td style="text-align: left;padding:5px">{{ value.quantity }}</td>
-            <td style="text-align: left;padding:5px">{{ value.pretax_price }}</td>
-            <td style="text-align: left;padding:5px">{{ value.tax_percentage }}</td>
-            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.pretax_price }}</td>
+            <td class="order-details-values-first">{{ value.reservation_name }}, {{ unit }}</td>
+            <td class="order-details-values-middle">{{ value.quantity }}</td>
+            <td class="order-details-values-middle">{{ value.pretax_price }}</td>
+            <td class="order-details-values-middle">{{ value.tax_percentage }}</td>
+            <td class="order-details-values-last-value">{{ value.pretax_price }}</td>
         </tr>
         {% endfor %}
         </tbody>
@@ -104,16 +104,16 @@
 <table>
     <tbody>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Tax-free price total</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format((order_details|sum(attribute='pretax_price_num') * order_details[0].quantity)|round(2))  }}€</td>
+        <td class="order-summary-headers">Tax-free price total</td>
+        <td class="order-summary-values">{{ "%.2f"|format((order_details|sum(attribute='pretax_price_num') * order_details[0].quantity)|round(2))  }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">VAT {{ order_details[0].tax_percentage }} total</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format( (order_details|sum(attribute='tax_price_num') * order_details[0].quantity)|round(2)) }}€</td>
+        <td class="order-summary-headers">VAT {{ order_details[0].tax_percentage }} % total</td>
+        <td class="order-summary-values">{{ "%.2f"|format( (order_details|sum(attribute='tax_price_num') * order_details[0].quantity)|round(2)) }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Total</td>
-        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ "%.2f"|format(order_details|sum(attribute='unit_price_num')) }}€</td>
+        <td class="order-summary-headers">Total</td>
+        <td class="order-summary-values-last-value">{{ "%.2f"|format(order_details|sum(attribute='unit_price_num')) }}€</td>
     </tr>
     </tbody>
 </table>

--- a/pages/varaamo/payment/fi-payment_details.html
+++ b/pages/varaamo/payment/fi-payment_details.html
@@ -1,18 +1,18 @@
-<div style="padding: 0 0 0 0">
+<div class="billing-details">
     <table>
         <thead>
         <tr>
-            <th style="font-weight: bold; width: 50%">Maksajan tiedot</th>
-            <th style="font-weight: bold;width: 50%">Tapahtuman päivämäärä</th>
+            <th class="billing-details-headers">Maksajan tiedot</th>
+            <th class="billing-details-headers">Tapahtuman päivämäärä</th>
         </tr>
         </thead>
         <tbody>
         <tr>
             <td>
                 <div>
-                    <p style="margin-bottom: 0">{{ billing_first_name }} {{ billing_last_name }}</p>
-                    <p style="margin-bottom: 0">{{ billing_address_street }}</p>
-                    <p style="margin-bottom: 0">{{ billing_address_zip }} {{ billing_address_city }}</p>
+                    <p class="billing-details-values">{{ billing_first_name }} {{ billing_last_name }}</p>
+                    <p class="billing-details-values">{{ billing_address_street }}</p>
+                    <p class="billing-details-values">{{ billing_address_zip }} {{ billing_address_city }}</p>
                 </div>
             </td>
             <td>
@@ -22,14 +22,14 @@
         </tbody>
     </table>
 </div>
-<div style="padding-top: 20px;">
+<div class="payment-details">
     <table>
         <tr>
-            <td style="width: 50%">
+            <td class="payment-details-ids">
                 <table>
                     <thead>
                     <tr>
-                        <th style="font-weight: bold">Laskun tunniste</th>
+                        <th class="payment-details-bill-id">Laskun tunniste</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -41,7 +41,7 @@
                 <table>
                     <thead>
                     <tr>
-                        <th style="font-weight: bold;padding-top: 10px">Tapahtuman tunniste</th>
+                        <th class="payment-details-event-id">Tapahtuman tunniste</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -51,21 +51,21 @@
                     </tbody>
                 </table>
             </td>
-            <td style="width: 50%">
+            <td class="payment-details-seller">
                 <table>
                     <thead>
                     <tr>
-                        <th style="font-weight: bold">Myyjän tiedot</th>
+                        <th class="payment-details-seller-header">Myyjän tiedot</th>
                     </tr>
                     </thead>
                     <tbody>
                     <tr>
                         <td>
                             <div>
-                                <p style="margin-bottom: 0">Turun Kaupunki</p>
-                                <p style="margin-bottom: 0">PL 355</p>
-                                <p style="margin-bottom: 0">20101 TURKU</p>
-                                <p style="margin-bottom: 0">Y-tunnus 0204819-8</p>
+                                <p class="payment-details-seller-values">Turun Kaupunki</p>
+                                <p class="payment-details-seller-values">PL 355</p>
+                                <p class="payment-details-seller-values">20101 TURKU</p>
+                                <p class="payment-details-seller-values">Y-tunnus 0204819-8</p>
                             </div>
                         </td>
                     </tr>
@@ -76,26 +76,26 @@
     </table>
 </div>
 
-<div style="padding: 20px 0">
+<div class="order-details">
     <table>
         <thead>
-        <tr style="border: 1px solid">
-            <th style="padding:5px">Tuote/palvelu</th>
-            <th style="padding:5px">Määrä</th>
-            <th style="padding:5px">Veroton hinta</th>
-            <th style="padding:5px">Alv %</th>
-            <th style="padding:5px;text-align: center">Veroton yhteensä</th>
+        <tr class="order-details-headers-tr">
+            <th class="order-details-headers">Tuote/palvelu</th>
+            <th class="order-details-headers">Määrä</th>
+            <th class="order-details-headers">Yksikköhinta</th>
+            <th class="order-details-headers">Alv %</th>
+            <th class="order-details-headers-last-value">Veroton yhteensä</th>
         </tr>
         </thead>
         <tbody>
         {% for value in order_details %}
 
         <tr>
-            <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
-            <td style="text-align: left;padding:5px">{{ value.quantity }}</td>
-            <td style="text-align: left;padding:5px">{{ value.pretax_price }}</td>
-            <td style="text-align: left;padding:5px">{{ value.tax_percentage }}</td>
-            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.pretax_price }}</td>
+            <td class="order-details-values-first">{{ value.reservation_name }}, {{ unit }}</td>
+            <td class="order-details-values-middle">{{ value.quantity }}</td>
+            <td class="order-details-values-middle">{{ value.pretax_price }}</td>
+            <td class="order-details-values-middle">{{ value.tax_percentage }}</td>
+            <td class="order-details-values-last-value">{{ value.pretax_price }}</td>
         </tr>
         {% endfor %}
         </tbody>
@@ -104,16 +104,16 @@
 <table>
     <tbody>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Veroton hinta yhteensä</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format((order_details|sum(attribute='pretax_price_num') * order_details[0].quantity)|round(2))  }}€</td>
+        <td class="order-summary-headers">Veroton hinta yhteensä</td>
+        <td class="order-summary-values">{{ "%.2f"|format((order_details|sum(attribute='pretax_price_num') * order_details[0].quantity)|round(2))  }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">ALV {{ order_details[0].tax_percentage }} yhteensä</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format( (order_details|sum(attribute='tax_price_num') * order_details[0].quantity)|round(2)) }}€</td>
+        <td class="order-summary-headers">ALV {{ order_details[0].tax_percentage }} % yhteensä</td>
+        <td class="order-summary-values">{{ "%.2f"|format( (order_details|sum(attribute='tax_price_num') * order_details[0].quantity)|round(2)) }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Lasku yhteensä</td>
-        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ "%.2f"|format(order_details|sum(attribute='unit_price_num')) }}€</td>
+        <td class="order-summary-headers">Lasku yhteensä</td>
+        <td class="order-summary-values-last-value">{{ "%.2f"|format(order_details|sum(attribute='unit_price_num')) }}€</td>
     </tr>
     </tbody>
 </table>

--- a/pages/varaamo/payment/sv-payment_details.html
+++ b/pages/varaamo/payment/sv-payment_details.html
@@ -1,18 +1,18 @@
-<div style="padding: 0 0 0 0">
+<div class="billing-details">
     <table>
         <thead>
         <tr>
-            <th style="font-weight: bold; width: 50%">Köparens uppgifter</th>
-            <th style="font-weight: bold;width: 50%">Fakturans datum</th>
+            <th class="billing-details-headers">Köparens uppgifter</th>
+            <th class="billing-details-headers">Fakturans datum</th>
         </tr>
         </thead>
         <tbody>
         <tr>
             <td>
                 <div>
-                    <p style="margin-bottom: 0">{{ billing_first_name }} {{ billing_last_name }}</p>
-                    <p style="margin-bottom: 0">{{ billing_address_street }}</p>
-                    <p style="margin-bottom: 0">{{ billing_address_zip }} {{ billing_address_city }}</p>
+                    <p class="billing-details-values">{{ billing_first_name }} {{ billing_last_name }}</p>
+                    <p class="billing-details-values">{{ billing_address_street }}</p>
+                    <p class="billing-details-values">{{ billing_address_zip }} {{ billing_address_city }}</p>
                 </div>
             </td>
             <td>
@@ -22,14 +22,14 @@
         </tbody>
     </table>
 </div>
-<div style="padding-top: 20px;">
+<div class="payment-details">
     <table>
         <tr>
-            <td style="width: 50%">
+            <td class="payment-details-ids">
                 <table>
                     <thead>
                     <tr>
-                        <th style="font-weight: bold">Fakturanummer</th>
+                        <th class="payment-details-bill-id">Fakturanummer</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -41,7 +41,7 @@
                 <table>
                     <thead>
                     <tr>
-                        <th style="font-weight: bold;padding-top: 10px">Händelsenummer</th>
+                        <th class="payment-details-event-id">Händelsenummer</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -51,21 +51,21 @@
                     </tbody>
                 </table>
             </td>
-            <td style="width: 50%">
+            <td class="payment-details-seller">
                 <table>
                     <thead>
                     <tr>
-                        <th style="font-weight: bold">Säljarens uppgifter</th>
+                        <th class="payment-details-seller-header">Säljarens uppgifter</th>
                     </tr>
                     </thead>
                     <tbody>
                     <tr>
                         <td>
                             <div>
-                                <p style="margin-bottom: 0">Åbo Stad</p>
-                                <p style="margin-bottom: 0">PO 355</p>
-                                <p style="margin-bottom: 0">20101 ÅBO</p>
-                                <p style="margin-bottom: 0">FO-nummer 0204819-8</p>
+                                <p class="payment-details-seller-values">Åbo Stad</p>
+                                <p class="payment-details-seller-values">PO 355</p>
+                                <p class="payment-details-seller-values">20101 ÅBO</p>
+                                <p class="payment-details-seller-values">FO-nummer 0204819-8</p>
                             </div>
                         </td>
                     </tr>
@@ -76,26 +76,26 @@
     </table>
 </div>
 
-<div style="padding: 20px 0">
+<div class="order-details">
     <table>
         <thead>
-        <tr style="border: 1px solid">
-            <th style="padding:5px">Produkt/service</th>
-            <th style="padding:5px">Mängd</th>
-            <th style="padding:5px">Skattefritt pris</th>
-            <th style="padding:5px">Moms %</th>
-            <th style="padding:5px;text-align: center">Totala skattefria</th>
+        <tr class="order-details-headers-tr">
+            <th class="order-details-headers">Produkt/service</th>
+            <th class="order-details-headers">Mängd</th>
+            <th class="order-details-headers">Enhetspris</th>
+            <th class="order-details-headers">Moms %</th>
+            <th class="order-details-headers-last-value">Totala skattefria</th>
         </tr>
         </thead>
         <tbody>
         {% for value in order_details %}
 
         <tr>
-            <td style="padding:5px">{{ value.reservation_name }}, {{ unit }}</td>
-            <td style="text-align: left;padding:5px">{{ value.quantity }}</td>
-            <td style="text-align: left;padding:5px">{{ value.pretax_price }}</td>
-            <td style="text-align: left;padding:5px">{{ value.tax_percentage }}</td>
-            <td style="text-align: right;padding:5px 35px 5px 5px">{{ value.pretax_price }}</td>
+            <td class="order-details-values-first">{{ value.reservation_name }}, {{ unit }}</td>
+            <td class="order-details-values-middle">{{ value.quantity }}</td>
+            <td class="order-details-values-middle">{{ value.pretax_price }}</td>
+            <td class="order-details-values-middle">{{ value.tax_percentage }}</td>
+            <td class="order-details-values-last-value">{{ value.pretax_price }}</td>
         </tr>
         {% endfor %}
         </tbody>
@@ -104,16 +104,16 @@
 <table>
     <tbody>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Totala skattefria priset</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format((order_details|sum(attribute='pretax_price_num') * order_details[0].quantity)|round(2))  }}€</td>
+        <td class="order-summary-headers">Totala skattefria priset</td>
+        <td class="order-summary-values">{{ "%.2f"|format((order_details|sum(attribute='pretax_price_num') * order_details[0].quantity)|round(2))  }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Moms {{ order_details[0].tax_percentage }} totalt</td>
-        <td style="padding:5px 35px 5px 5px; text-align: right">{{ "%.2f"|format( (order_details|sum(attribute='tax_price_num') * order_details[0].quantity)|round(2)) }}€</td>
+        <td class="order-summary-headers">Moms {{ order_details[0].tax_percentage }} % totalt</td>
+        <td class="order-summary-values">{{ "%.2f"|format( (order_details|sum(attribute='tax_price_num') * order_details[0].quantity)|round(2)) }}€</td>
     </tr>
     <tr>
-        <td style="text-align: right;padding:5px;font-weight: bold">Totala priset</td>
-        <td style="padding:5px 35px 5px 5px;text-align: right; width: 100px">{{ "%.2f"|format(order_details|sum(attribute='unit_price_num')) }}€</td>
+        <td class="order-summary-headers">Totala priset</td>
+        <td class="order-summary-values-last-value">{{ "%.2f"|format(order_details|sum(attribute='unit_price_num')) }}€</td>
     </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Changes:
 - refactored payment details styling, removed inlined styles and replaced them with normal css classes.
 - changed the order details <th> text from `tax-free price` -> `unit price`