### PR TITLE
Feature/reservation waiting payment templates

### DIFF
--- a/pages/varaamo/en/en-reservation_confirmed.html
+++ b/pages/varaamo/en/en-reservation_confirmed.html
@@ -6,6 +6,11 @@
 <p>Start: {{ begin }}</p>
 <p>End: {{ end }}</p>
 <p></p>
+{% if order is defined %}
+<hr />
+<!--inject:order:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/en/en-reservation_waiting_payment.html
+++ b/pages/varaamo/en/en-reservation_waiting_payment.html
@@ -1,0 +1,19 @@
+<p>Hello,</p>
+<p>Your reservation has been approved and is waiting for payment.</p>
+<p>You can pay for the reservation by logging in to Varaamo, go to 'Your reservations' and pressing the 'Pay' button for this specific reservation.</p>
+{% if payment_due_date is defined %}
+<p>Payment due date {{ payment_due_date }}. Unpaid reservations are cancelled after payment due date.</p>
+{% endif %}
+<hr />
+<p>Resource: {{ resource }}</p>
+<p>Unit: {{ unit }}</p>
+<p>Start: {{ begin }}</p>
+<p>End: {{ end }}</p>
+<p></p>
+<hr />
+{% if extra_content is defined %}
+{{ extra_content }}
+{% endif %}
+<p>Your reservation has been approved and is waiting for payment. A separate email confirming the reservation
+including a receipt will be sent after payment has occurred.</p>
+<p>Best regards, Varaamo</p>

--- a/pages/varaamo/fi/fi-reservation_confirmed.html
+++ b/pages/varaamo/fi/fi-reservation_confirmed.html
@@ -6,6 +6,11 @@
 <p>Alkaa: {{ begin }}</p>
 <p>Loppuu: {{ end }}</p>
 <p></p>
+{% if order is defined %}
+<hr />
+<!--inject:order:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/fi/fi-reservation_waiting_payment.html
+++ b/pages/varaamo/fi/fi-reservation_waiting_payment.html
@@ -1,0 +1,18 @@
+<p>Hei,</p>
+<p>Varauksesi on hyväksytty ja odottaa maksua.</p>
+<p>Voit siirtyä varauksen maksuun kirjautumalla Varaamoon ja Omat varaukset -sivulta painamalla 'Maksa'-nappia tämän varauksen kohdalta.</p>
+{% if payment_due_date is defined %}
+<p>Maksettava viimeistään {{ payment_due_date }} mennessä. Tämän jälkeen maksamatta jäänyt varaus peruutetaan.</p>
+{% endif %}
+<hr />
+<p>Palvelu: {{ resource }}</p>
+<p>Toimipiste: {{ unit }}</p>
+<p>Alkaa: {{ begin }}</p>
+<p>Loppuu: {{ end }}</p>
+<p></p>
+<hr />
+{% if extra_content is defined %}
+{{ extra_content }}
+{% endif %}
+<p>Varauksesi on hyväksytty ja odottaa maksua. Kun olet maksanut saat erillisen sähköpostin, joka sisältää tilausvahvistuksen.</p>
+<p>Ystävällisin terveisin, Varaamo</p>

--- a/pages/varaamo/sv/sv-reservation_confirmed.html
+++ b/pages/varaamo/sv/sv-reservation_confirmed.html
@@ -6,6 +6,11 @@
 <p>Börjar: {{ begin }}</p>
 <p>Slutar: {{ end }}</p>
 <p></p>
+{% if order is defined %}
+<hr />
+<!--inject:order:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/sv/sv-reservation_requested.html
+++ b/pages/varaamo/sv/sv-reservation_requested.html
@@ -1,6 +1,6 @@
 <p>Hej,</p>
 <p>och tack för att du använder Varaamo!</p>
-<p>Du har gjort en preliminär reservation:</p>
+<p>Du har gjort en preliminär bokning:</p>
 <hr />
 <p>Utrymme: {{ resource }}</p>
 <p>Plats: {{ unit }}</p>
@@ -33,6 +33,6 @@
 {{ extra_content }}
 {% endif %}
 <p>Du får ett e-postmeddelande när din bokning antingen bekräftas eller
-    nekas. Om vi behöver mer information om bokningen kommer vi att kontakta
+    avvisas. Om vi behöver mer information om bokningen kommer vi att kontakta
     dig.</p>
 <p>Med vänliga hälsningar, Varaamo</p>

--- a/pages/varaamo/sv/sv-reservation_waiting_payment.html
+++ b/pages/varaamo/sv/sv-reservation_waiting_payment.html
@@ -1,0 +1,19 @@
+<p>Hej,</p>
+<p>Din bokning har godkänts och väntar på betalning.</p>
+<p>Du kan göra betalning genom att logga in på Varaamo, gå till 'Mina bokningar' sidan och tryck på 'Betala' knappen på bokningen.</p>
+{% if payment_due_date is defined %}
+<p>Bokningen måste betalas senast {{ payment_due_date }}. Om bokningen är obetald efter denna datum så annulleras bokningen.</p>
+{% endif %}
+<hr />
+<p>Utrymme: {{ resource }}</p>
+<p>Plats: {{ unit }}</p>
+<p>Börjar: {{ begin }}</p>
+<p>Slutar: {{ end }}</p>
+<p></p>
+<hr />
+{% if extra_content is defined %}
+{{ extra_content }}
+{% endif %}
+<p>Din bokning har godkänts och väntar på betalning. Efter att bokningen har blivit betald så får du bekräftnings e-post som
+innehåller kvittot/betalningsbekräftelse.</p>
+<p>Med vänliga hälsningar, Varaamo</p>

--- a/pages/varaamo/sv/sv-reservation_waiting_payment.html
+++ b/pages/varaamo/sv/sv-reservation_waiting_payment.html
@@ -15,5 +15,5 @@
 {{ extra_content }}
 {% endif %}
 <p>Din bokning har godkänts och väntar på betalning. Efter att bokningen har blivit betald så får du bekräftnings e-post som
-innehåller kvittot/betalningsbekräftelse.</p>
+innehåller kvitto.</p>
 <p>Med vänliga hälsningar, Varaamo</p>


### PR DESCRIPTION
Changes:
- Added new `reservation_waiting_payment` templates for all languages, if `payment_due_date` is added to context then the payment due date text is also enabled.
- Added missing order injections to `reservation_confirmed` templates.
- Minor change to `sv-reservation_requested` template texts.