### PR TITLE
detailed pricing information for orders

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -146,11 +146,12 @@ function generateTemplates(cb, lang = 'FI', files = [], service = 'varaamo') {
                 url: 'file://' + __dirname + '/pages/template/', // specifies the base path for the stylesheet links
                 applyStyleTags: true,
                 applyLinkTags: true,
-                removeStyleTags: true,
+                removeStyleTags: false,
                 removeLinkTags: true
             }))
             .pipe(htmlmin({ // minify html
-                collapseWhitespace: true
+                collapseWhitespace: true,
+                minifyCSS: true
             }))
             .pipe(rename(fileName)) // rename index.html according to fileName
             .pipe(gulp.dest(FILE_PATH[upperCaseService][lang].DEST)) // write to destination

--- a/pages/css/turku-custom.css
+++ b/pages/css/turku-custom.css
@@ -89,6 +89,11 @@
 .order-details-values-first {
     padding: 5px;
 }
+
+.order-details-values-first-sub {
+    padding: 5px;
+
+}
 .order-details-values-middle {
     text-align: left;
     padding: 5px;

--- a/pages/template/index.html
+++ b/pages/template/index.html
@@ -7,6 +7,10 @@
     <title>Title</title>
     <link rel="stylesheet" href="../css/foundation-emails.css" />
     <link rel="stylesheet" href="../css/turku-custom.css" />
+    <style type="text/css">
+        .highlight {background-color: #f8f8f8;}
+        .order-details-values-first-sub::before {content: '\2022';padding-right: 5px;}
+    </style>
 </head>
 
 <body>

--- a/pages/varaamo/payment/en-payment_details.html
+++ b/pages/varaamo/payment/en-payment_details.html
@@ -120,9 +120,9 @@
                     {# product doesn't have per_period pricing -> list normally in one row #}
                     {% for key, val in product.detailed_price.items() %}
                         <td class="order-details-values-middle">{{ val.count }}</td>
-                        <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                        <td class="order-details-values-middle">{{ val.taxfree_price|string|replace('.',',') }}</td>
                         <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
-                        <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                        <td class="order-details-values-last-value">{{ val.taxfree_price_total|string|replace('.',',') }}</td>
                     {% endfor %}
                 {% endif %}
             </tr>
@@ -142,9 +142,9 @@
                             <th headers="{{ product.id }}-name" scope="row" class="order-details-values-first-sub">{{ val.time.begin }} - {{ val.time.end }}</th>
                         {% endif %}
                         <td class="order-details-values-middle">{{ val.count }}</td>
-                        <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                        <td class="order-details-values-middle">{{ val.taxfree_price|string|replace('.',',') }}</td>
                         <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
-                        <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                        <td class="order-details-values-last-value">{{ val.taxfree_price_total|string|replace('.',',') }}</td>
                     </tr>
                 {% endfor %}
             {% endif %}

--- a/pages/varaamo/payment/en-payment_details.html
+++ b/pages/varaamo/payment/en-payment_details.html
@@ -81,60 +81,97 @@
     <table>
         <thead>
         <tr class="order-details-headers-tr">
-            <th class="order-details-headers">Product/service</th>
-            <th class="order-details-headers">Quantity</th>
-            <th class="order-details-headers">Unit price</th>
-            <th class="order-details-headers">VAT %</th>
-            <th class="order-details-headers-last-value">Total tax-free price</th>
+            <th id="product" scope="col" class="order-details-headers">Product/service</th>
+            <th id="quantity" scope="col" class="order-details-headers">Quantity</th>
+            <th id="unit-price" scope="col" class="order-details-headers">Unit price</th>
+            <th id="vat" scope="col" class="order-details-headers">VAT %</th>
+            <th id="taxfree-total" scope="col" class="order-details-headers-last-value">Total tax-free price</th>
         </tr>
         </thead>
         <tbody>
-        {% for value in order_details %}
+        {#
+            global variables and their purpose:
+            multiple - determines whether a product's pricing should be shown in separate nested rows.
+            detailed_info - determines if a separate explanation paragraph for detailed pricing is rendered
+            after the table, true when product has per_period pricing and quantity is more than 2.
+        #}
+        {% set global = namespace(multiple=true) %}
+        {% set global = namespace(detailed_info=false) %}
+        {% for product in order_details %}
+            {% set global.multiple = true %}
+            {% if product.detailed_price|count == 1%}
+                {% set global.multiple = false %}
+            {% endif %}
+            {% set alternating_highlight = loop.cycle('', 'highlight')  %}
+            <tr class="{{ alternating_highlight }}">
+                <th id="{{ product.id }}-name" scope="row" class="order-details-values-first">{{ product.name }}, {{ unit }}</th>
+                {% if 'product_quantity' in product.keys() %}
+                    {# product_quantity key only exists in products with per_period pricing #}
+                    {% set global.multiple = true %}
+                    <td class="order-details-values-middle">{{ product.product_quantity }}</td>
+                    <td class="order-details-values-middle">&nbsp;</td>
+                    <td class="order-details-values-middle">&nbsp;</td>
+                    <td class="order-details-values-last-value">{{ product.product_taxfree_total|string|replace('.',',') }}</td>
+                    {% if product.product_quantity not in [1, 1.0] %}
+                        {% set global.detailed_info = true %}
+                    {% endif %}
+                {% endif %}
+                {% if global.multiple == false %}
+                    {# product doesn't have per_period pricing -> list normally in one row #}
+                    {% for key, val in product.detailed_price.items() %}
+                        <td class="order-details-values-middle">{{ val.count }}</td>
+                        <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                        <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
+                        <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                    {% endfor %}
+                {% endif %}
+            </tr>
+            {% if global.multiple == true %}
+                {% if global.detailed_info == true %}
+                    <tr class="{{ alternating_highlight }}">
+                        <th class="order-details-values-first" colspan="5">detailed price breakdown*</th>
+                    </tr>
+                {% endif %}
 
-        <tr>
-            <td class="order-details-values-first">{{ value.name }}, {{ unit }}</td>
-            <td class="order-details-values-middle">{{ value.quantity }}</td>
-            <td class="order-details-values-middle">{{ value.pretax_price_num|string|replace('.', ',') }}</td>
-            <td class="order-details-values-middle">{{ value.tax_percentage }}</td>
-            <td class="order-details-values-last-value">{{ (value.pretax_price_num * value.quantity)|string|replace('.', ',') }}</td>
-        </tr>
+                {% for key, val in product.detailed_price.items() %}
+                    {# render each pricing #}
+                    <tr class="{{ alternating_highlight }}">
+                        {% if key == 'default' %}
+                            <th headers="{{ product.id }}-name" scope="row" class="order-details-values-first-sub">default price</th>
+                        {% else %}
+                            <th headers="{{ product.id }}-name" scope="row" class="order-details-values-first-sub">{{ val.time.begin }} - {{ val.time.end }}</th>
+                        {% endif %}
+                        <td class="order-details-values-middle">{{ val.count }}</td>
+                        <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                        <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
+                        <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                    </tr>
+                {% endfor %}
+            {% endif %}
         {% endfor %}
         </tbody>
     </table>
 </div>
+{% if global.detailed_info == true %}
+<p>*Price breakdown is only shown for one count of a product if the reservation includes multiple counts of a product. Total price is calculated by multiplying the total price of each row in the breakdown with the quantity of the product.</p>
+{% endif %}
 <table>
-    {% set global = namespace(total=0) %}
     <tbody>
-    {% set ns = namespace(total=0) %}
-    {% for id, prod in order_details|groupby("id") %}
-    {% set temp_price = prod|sum(attribute='pretax_price_num') * prod|sum(attribute='quantity') %}
-    {% set ns.total = ns.total + temp_price %}
-    {% endfor %}
-    {% set global.total = global.total + ns.total %}
-    <tr>
-        <td class="order-summary-headers">Tax-free price total</td>
-        {% set tax_free_total = "%.2f"|format(ns.total|round(2)) %}
-        <td class="order-summary-values">{{ tax_free_total|replace('.', ',') }} euro</td>
-    </tr>
-    {% for alv, prod in order_details|groupby("tax_percentage") %}
-        {% if alv not in ['0,00', '0.00']  %}
         <tr>
-            <td class="order-summary-headers">VAT {{ alv }} % total</td>
-            {% set ns = namespace(total=0) %}
-            {% for obj in prod %}
-            {% set ns.total = ns.total + (obj['tax_price_num'] * obj['quantity']) %}
-            {% endfor %}
-            {% set global.total = global.total + ns.total %}
-            {% set tax_string = "%.2f"|format(ns.total|round(2)) %}
-            <td class="order-summary-values">{{ tax_string|replace('.', ',') }} euro</td>
+            <td class="order-summary-headers">Tax-free price total</td>
+            <td class="order-summary-values">{{ order_taxfree_total|string|replace('.',',') }} euro</td>
         </tr>
-        {% endif %}
-    {% endfor %}
-    <tr>
-        <td class="order-summary-headers">Total</td>
-        {% set total_string = "%.2f"|format(global.total|round(2)) %}
-        <td class="order-summary-values-last-value">{{ total_string|replace('.', ',') }} euro</td>
-
-    </tr>
+        {% for key, val in detailed_tax_sums|dictsort %}
+            {% if key not in ['0,00', '0.00'] %}
+                <tr>
+                    <td class="order-summary-headers">VAT {{ key }} % total</td>
+                    <td class="order-summary-values">{{ val|string|replace('.',',') }} euro</td>
+                </tr>
+            {% endif %}
+        {% endfor %}
+        <tr>
+            <td class="order-summary-headers">Total</td>
+            <td class="order-summary-values-last-value">{{ order_total|string|replace('.',',') }} euro</td>
+        </tr>
     </tbody>
 </table>

--- a/pages/varaamo/payment/fi-payment_details.html
+++ b/pages/varaamo/payment/fi-payment_details.html
@@ -121,9 +121,9 @@
                 {# product doesn't have per_period pricing -> list normally in one row #}
                     {% for key, val in product.detailed_price.items() %}
                         <td class="order-details-values-middle">{{ val.count }}</td>
-                        <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                        <td class="order-details-values-middle">{{ val.taxfree_price|string|replace('.',',') }}</td>
                         <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
-                        <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                        <td class="order-details-values-last-value">{{ val.taxfree_price_total|string|replace('.',',') }}</td>
                     {% endfor %}
                 {% endif %}
             </tr>
@@ -143,9 +143,9 @@
                     <th headers="{{ product.id }}-name" scope="row" class="order-details-values-first-sub">{{ val.time.begin }} - {{ val.time.end }}</th>
                     {% endif %}
                     <td class="order-details-values-middle">{{ val.count }}</td>
-                    <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                    <td class="order-details-values-middle">{{ val.taxfree_price|string|replace('.',',') }}</td>
                     <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
-                    <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                    <td class="order-details-values-last-value">{{ val.taxfree_price_total|string|replace('.',',') }}</td>
                 </tr>
                 {% endfor %}
             {% endif %}

--- a/pages/varaamo/payment/fi-payment_details.html
+++ b/pages/varaamo/payment/fi-payment_details.html
@@ -81,60 +81,98 @@
     <table>
         <thead>
         <tr class="order-details-headers-tr">
-            <th class="order-details-headers">Tuote/palvelu</th>
-            <th class="order-details-headers">Määrä</th>
-            <th class="order-details-headers">Yksikköhinta</th>
-            <th class="order-details-headers">Alv %</th>
-            <th class="order-details-headers-last-value">Veroton yhteensä</th>
+            <th id="product" scope="col" class="order-details-headers">Tuote/palvelu</th>
+            <th id="quantity" scope="col" class="order-details-headers">Määrä</th>
+            <th id="unit-price" scope="col" class="order-details-headers">Yksikköhinta</th>
+            <th id="vat" scope="col" class="order-details-headers">Alv %</th>
+            <th id="taxfree-total" scope="col" class="order-details-headers-last-value">Veroton yhteensä</th>
         </tr>
         </thead>
         <tbody>
-        {% for value in order_details %}
+        {#
+            global variables and their purpose:
+            multiple - determines whether a product's pricing should be shown in separate nested rows.
+            detailed_info - determines if a separate explanation paragraph for detailed pricing is rendered
+                            after the table, true when product has per_period pricing and quantity is more than 2.
+        #}
+        {% set global = namespace(multiple=true) %}
+        {% set global = namespace(detailed_info=false) %}
+        {% for product in order_details %}
+            {% set global.multiple = true %}
+            {% if product.detailed_price|count == 1%}
+                {% set global.multiple = false %}
+            {% endif %}
+            {% set alternating_highlight = loop.cycle('', 'highlight')  %}
+            <tr class="{{ alternating_highlight }}">
+                <th id="{{ product.id }}-name" scope="row" class="order-details-values-first">{{ product.name }}, {{ unit }}</th>
+                {% if 'product_quantity' in product.keys() %}
+                {# product_quantity key only exists in products with per_period pricing #}
+                    {% set global.multiple = true %}
+                    <td class="order-details-values-middle">{{ product.product_quantity }}</td>
+                    <td class="order-details-values-middle">&nbsp;</td>
+                    <td class="order-details-values-middle">&nbsp;</td>
+                    <td class="order-details-values-last-value">{{ product.product_taxfree_total|string|replace('.',',') }}</td>
+                    {% if product.product_quantity not in [1, 1.0] %}
+                        {% set global.detailed_info = true %}
+                    {% endif %}
 
-        <tr>
-            <td class="order-details-values-first">{{ value.name }}, {{ unit }}</td>
-            <td class="order-details-values-middle">{{ value.quantity }}</td>
-            <td class="order-details-values-middle">{{ value.pretax_price_num|string|replace('.', ',') }}</td>
-            <td class="order-details-values-middle">{{ value.tax_percentage }}</td>
-            <td class="order-details-values-last-value">{{ (value.pretax_price_num * value.quantity)|string|replace('.', ',') }}</td>
-        </tr>
+                {% endif %}
+                {% if global.multiple == false %}
+                {# product doesn't have per_period pricing -> list normally in one row #}
+                    {% for key, val in product.detailed_price.items() %}
+                        <td class="order-details-values-middle">{{ val.count }}</td>
+                        <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                        <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
+                        <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                    {% endfor %}
+                {% endif %}
+            </tr>
+            {% if global.multiple == true %}
+                {% if global.detailed_info == true %}
+                    <tr class="{{ alternating_highlight }}">
+                        <th class="order-details-values-first" colspan="5">1kpl hintaerittely*</th>
+                    </tr>
+                {% endif %}
+
+                {% for key, val in product.detailed_price.items() %}
+                {# render each pricing #}
+                <tr class="{{ alternating_highlight }}">
+                    {% if key == 'default' %}
+                    <th headers="{{ product.id }}-name" scope="row" class="order-details-values-first-sub">normaalihinta</th>
+                    {% else %}
+                    <th headers="{{ product.id }}-name" scope="row" class="order-details-values-first-sub">{{ val.time.begin }} - {{ val.time.end }}</th>
+                    {% endif %}
+                    <td class="order-details-values-middle">{{ val.count }}</td>
+                    <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                    <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
+                    <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                </tr>
+                {% endfor %}
+            {% endif %}
         {% endfor %}
         </tbody>
     </table>
 </div>
+{% if global.detailed_info == true %}
+<p>*Ainoastaan yhden kappaleen hinnat eritellään jos varaus sisältää useamman kappaleen samaa tuotetta. Loppusumma koostuu eriteltyjen rivien summista kerrottuna tuotteen lukumäärällä.</p>
+{% endif %}
 <table>
-    {% set global = namespace(total=0) %}
     <tbody>
-    {% set ns = namespace(total=0) %}
-    {% for id, prod in order_details|groupby("id") %}
-        {% set temp_price = prod|sum(attribute='pretax_price_num') * prod|sum(attribute='quantity') %}
-        {% set ns.total = ns.total + temp_price %}
-    {% endfor %}
-    {% set global.total = global.total + ns.total %}
     <tr>
         <td class="order-summary-headers">Veroton hinta yhteensä</td>
-        {% set tax_free_total = "%.2f"|format(ns.total|round(2)) %}
-        <td class="order-summary-values">{{ tax_free_total|replace('.', ',') }} euroa</td>
+        <td class="order-summary-values">{{ order_taxfree_total|string|replace('.',',') }} euroa</td>
     </tr>
-
-    {% for alv, prod in order_details|groupby("tax_percentage") %}
-        {% if alv not in ['0,00', '0.00']  %}
+    {% for key, val in detailed_tax_sums|dictsort %}
+        {% if key not in ['0,00', '0.00'] %}
             <tr>
-                <td class="order-summary-headers">ALV {{ alv }} % yhteensä</td>
-                {% set ns = namespace(total=0) %}
-                {% for obj in prod %}
-                    {% set ns.total = ns.total + (obj['tax_price_num'] * obj['quantity']) %}
-                {% endfor %}
-                {% set global.total = global.total + ns.total %}
-                {% set tax_string = "%.2f"|format(ns.total|round(2)) %}
-                <td class="order-summary-values">{{ tax_string|replace('.', ',') }} euroa</td>
+                <td class="order-summary-headers">ALV {{ key }} % yhteensä</td>
+                <td class="order-summary-values">{{ val|string|replace('.',',') }} euroa</td>
             </tr>
         {% endif %}
     {% endfor %}
     <tr>
         <td class="order-summary-headers">Lasku yhteensä</td>
-        {% set total_string = "%.2f"|format(global.total|round(2)) %}
-        <td class="order-summary-values-last-value">{{ total_string|replace('.', ',') }} euroa</td>
+        <td class="order-summary-values-last-value">{{ order_total|string|replace('.',',') }} euroa</td>
     </tr>
     </tbody>
 </table>

--- a/pages/varaamo/payment/sv-payment_details.html
+++ b/pages/varaamo/payment/sv-payment_details.html
@@ -80,60 +80,97 @@
     <table>
         <thead>
         <tr class="order-details-headers-tr">
-            <th class="order-details-headers">Produkt/service</th>
-            <th class="order-details-headers">Mängd</th>
-            <th class="order-details-headers">Enhetspris</th>
-            <th class="order-details-headers">Moms %</th>
-            <th class="order-details-headers-last-value">Totala skattefria</th>
+            <th id="product" scope="col" class="order-details-headers">Produkt/service</th>
+            <th id="quantity" scope="col" class="order-details-headers">Mängd</th>
+            <th id="unit-price" scope="col" class="order-details-headers">Enhetspris</th>
+            <th id="vat" scope="col" class="order-details-headers">Moms %</th>
+            <th id="taxfree-total" scope="col" class="order-details-headers-last-value">Totala skattefria</th>
         </tr>
         </thead>
         <tbody>
-        {% for value in order_details %}
+            {#
+                global variables and their purpose:
+                multiple - determines whether a product's pricing should be shown in separate nested rows.
+                detailed_info - determines if a separate explanation paragraph for detailed pricing is rendered
+                                after the table, true when product has per_period pricing and quantity is more than 2.
+            #}
+            {% set global = namespace(multiple=true) %}
+            {% set global = namespace(detailed_info=false) %}
+            {% for product in order_details %}
+                {% set global.multiple = true %}
+                {% if product.detailed_price|count == 1%}
+                    {% set global.multiple = false %}
+                {% endif %}
+                {% set alternating_highlight = loop.cycle('', 'highlight')  %}
+                <tr class="{{ alternating_highlight }}">
+                    <th id="{{ product.id }}-name" scope="row" class="order-details-values-first">{{ product.name }}, {{ unit }}</th>
+                    {% if 'product_quantity' in product.keys() %}
+                        {# product_quantity key only exists in products with per_period pricing #}
+                        {% set global.multiple = true %}
+                        <td class="order-details-values-middle">{{ product.product_quantity }}</td>
+                        <td class="order-details-values-middle">&nbsp;</td>
+                        <td class="order-details-values-middle">&nbsp;</td>
+                        <td class="order-details-values-last-value">{{ product.product_taxfree_total|string|replace('.',',') }}</td>
+                        {% if product.product_quantity not in [1, 1.0] %}
+                            {% set global.detailed_info = true %}
+                        {% endif %}
+                    {% endif %}
+                    {% if global.multiple == false %}
+                        {# product doesn't have per_period pricing -> list normally in one row #}
+                        {% for key, val in product.detailed_price.items() %}
+                            <td class="order-details-values-middle">{{ val.count }}</td>
+                            <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                            <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
+                            <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                        {% endfor %}
+                    {% endif %}
+                </tr>
+                {% if global.multiple == true %}
+                    {% if global.detailed_info == true %}
+                        <tr class="{{ alternating_highlight }}">
+                            <th class="order-details-values-first" colspan="5">prisfördelning*</th>
+                        </tr>
+                    {% endif %}
 
-        <tr>
-            <td class="order-details-values-first">{{ value.name }}, {{ unit }}</td>
-            <td class="order-details-values-middle">{{ value.quantity }}</td>
-            <td class="order-details-values-middle">{{ value.pretax_price_num|string|replace('.', ',') }}</td>
-            <td class="order-details-values-middle">{{ value.tax_percentage }}</td>
-            <td class="order-details-values-last-value">{{ (value.pretax_price_num * value.quantity)|string|replace('.', ',') }}</td>
-        </tr>
-        {% endfor %}
+                    {% for key, val in product.detailed_price.items() %}
+                        {# render each pricing #}
+                        <tr class="{{ alternating_highlight }}">
+                            {% if key == 'default' %}
+                                <th headers="{{ product.id }}-name" scope="row" class="order-details-values-first-sub">normalpris</th>
+                            {% else %}
+                                <th headers="{{ product.id }}-name" scope="row" class="order-details-values-first-sub">{{ val.time.begin }} - {{ val.time.end }}</th>
+                            {% endif %}
+                            <td class="order-details-values-middle">{{ val.count }}</td>
+                            <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                            <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
+                            <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                        </tr>
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
         </tbody>
     </table>
 </div>
+{% if global.detailed_info == true %}
+<p>*Prisfördelning visas endast av ett stycke av produkten då bokningen innehåller flera stycken av samma produkt. Produktens totala pris räknas genom att multiplicera varje fördelade rads totala skattefria med produktens mängd.</p>
+{% endif %}
 <table>
-    {% set global = namespace(total=0) %}
     <tbody>
-    {% set ns = namespace(total=0) %}
-    {% for id, prod in order_details|groupby("id") %}
-    {% set temp_price = prod|sum(attribute='pretax_price_num') * prod|sum(attribute='quantity') %}
-    {% set ns.total = ns.total + temp_price %}
-    {% endfor %}
-    {% set global.total = global.total + ns.total %}
-    <tr>
-        <td class="order-summary-headers">Totala skattefria priset</td>
-        {% set tax_free_total = "%.2f"|format(ns.total|round(2)) %}
-        <td class="order-summary-values">{{ tax_free_total|replace('.', ',') }} euro</td>
-    </tr>
-    {% for alv, prod in order_details|groupby("tax_percentage") %}
-        {% if alv not in ['0,00', '0.00']  %}
         <tr>
-            <td class="order-summary-headers">Moms {{ alv }} % totalt</td>
-            {% set ns = namespace(total=0) %}
-            {% for obj in prod %}
-            {% set ns.total = ns.total + (obj['tax_price_num'] * obj['quantity']) %}
-            {% endfor %}
-            {% set global.total = global.total + ns.total %}
-            {% set tax_string = "%.2f"|format(ns.total|round(2)) %}
-            <td class="order-summary-values">{{ tax_string|replace('.', ',') }} euro</td>
+            <td class="order-summary-headers">Totala skattefria priset</td>
+            <td class="order-summary-values">{{ order_taxfree_total|string|replace('.',',') }} euro</td>
         </tr>
-        {% endif %}
-    {% endfor %}
-    <tr>
-        <td class="order-summary-headers">Totala priset</td>
-        {% set total_string = "%.2f"|format(global.total|round(2)) %}
-        <td class="order-summary-values-last-value">{{ total_string|replace('.', ',') }} euro</td>
-
-    </tr>
+        {% for key, val in detailed_tax_sums|dictsort %}
+            {% if key not in ['0,00', '0.00'] %}
+                <tr>
+                    <td class="order-summary-headers">Moms {{ key }} % totalt</td>
+                    <td class="order-summary-values">{{ val|string|replace('.',',') }} euro</td>
+                </tr>
+            {% endif %}
+        {% endfor %}
+        <tr>
+            <td class="order-summary-headers">Totala priset</td>
+            <td class="order-summary-values-last-value">{{ order_total|string|replace('.',',') }} euro</td>
+        </tr>
     </tbody>
 </table>

--- a/pages/varaamo/payment/sv-payment_details.html
+++ b/pages/varaamo/payment/sv-payment_details.html
@@ -119,9 +119,9 @@
                         {# product doesn't have per_period pricing -> list normally in one row #}
                         {% for key, val in product.detailed_price.items() %}
                             <td class="order-details-values-middle">{{ val.count }}</td>
-                            <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                            <td class="order-details-values-middle">{{ val.taxfree_price|string|replace('.',',') }}</td>
                             <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
-                            <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                            <td class="order-details-values-last-value">{{ val.taxfree_price_total|string|replace('.',',') }}</td>
                         {% endfor %}
                     {% endif %}
                 </tr>
@@ -141,9 +141,9 @@
                                 <th headers="{{ product.id }}-name" scope="row" class="order-details-values-first-sub">{{ val.time.begin }} - {{ val.time.end }}</th>
                             {% endif %}
                             <td class="order-details-values-middle">{{ val.count }}</td>
-                            <td class="order-details-values-middle">{{ val.pretax|string|replace('.',',') }}</td>
+                            <td class="order-details-values-middle">{{ val.taxfree_price|string|replace('.',',') }}</td>
                             <td class="order-details-values-middle">{{ product.tax_percentage }}</td>
-                            <td class="order-details-values-last-value">{{ val.taxfree_total|string|replace('.',',') }}</td>
+                            <td class="order-details-values-last-value">{{ val.taxfree_price_total|string|replace('.',',') }}</td>
                         </tr>
                     {% endfor %}
                 {% endif %}


### PR DESCRIPTION
# Detailed pricing information

#### Payment details now display timeslot specific price information. For example a 5h rent product will now display 5xdefault price if it only consists of the default pricing or it might show 4x1default and 1x1 timeslot pricing if it consists of 4 default prices and 1 timeslot specific price. The Product listing now highlights alternating rows to provide some clarity now that the amount of rows has multiplied.

-----------------------------------------------------------------------------------------------
Changes:
- **gulpfile.babel.js**
Inlined style tags are no longer removed, the alternating highlights required this change.
- **pages/css/turku-custom.css**
Added styling to add additional padding to the first sub pricing detail of a product.
- **pages/template/index.html**
Added style tag that includes the product highlighting and the bullet-point for the details listing.
- **pages/varaamo/payment/X-payment_details.html**
Reworked all language variants to now correctly display a detailed listing of a products pricing if the price-type if per_period. Changed the templates to use the new taxfree_price variables instead of the old pretax_price, taxfree_price is the new VAT-free price value of a product that is used when calculating VAT/totals.
