### PR TITLE
Update confirmed templates with text regarding cash reservations

### DIFF
--- a/pages/varaamo/en/en-reservation_confirmed.html
+++ b/pages/varaamo/en/en-reservation_confirmed.html
@@ -1,5 +1,10 @@
 <p>Hello,</p>
 <p>Your reservation has been confirmed.</p>
+{% if order is defined %}
+{% if order.payment_method == 'cash' %}
+<p>The reservation payment will be done on-site.</p>
+{% endif%}
+{% endif %}
 <hr />
 <p>Resource: {{ resource }}</p>
 <p>Unit: {{ unit }}</p>

--- a/pages/varaamo/fi/fi-reservation_confirmed.html
+++ b/pages/varaamo/fi/fi-reservation_confirmed.html
@@ -1,5 +1,10 @@
 <p>Hei,</p>
 <p>Varauksesi on hyväksytty.</p>
+{% if order is defined %}
+{% if order.payment_method == 'cash' %}
+<p>Varauksen maksaminen tapahtuu paikan päällä.</p>
+{% endif%}
+{% endif %}
 <hr />
 <p>Palvelu: {{ resource }}</p>
 <p>Toimipiste: {{ unit }}</p>

--- a/pages/varaamo/sv/sv-reservation_confirmed.html
+++ b/pages/varaamo/sv/sv-reservation_confirmed.html
@@ -1,5 +1,10 @@
 <p>Hej,</p>
 <p>Din bokning har bekräftats.</p>
+{% if order is defined %}
+{% if order.payment_method == 'cash' %}
+<p>Bokningens betalning sker på plats.</p>
+{% endif%}
+{% endif %}
 <hr />
 <p>Utrymme: {{ resource }}</p>
 <p>Plats: {{ unit }}</p>


### PR DESCRIPTION
# Added text to confirmed template regarding cash reservations


#### Updated the reservation-confirmed template with text informing the user that payment will be done on-site. The reservation-confirmed notification is sent to the user once a staff member has accepted the initial reservation requested that the user made.

[Trello card for this feature.](https://trello.com/c/tUKV7Nyw/305-s%C3%A4hk%C3%B6postipohjat-k%C3%A4teisvarauksille)
-----------------------------------------------------------------------------------------------
Changes:
- **pages/varaamo/[en,fi,sv]/[en,fi,sv]-reservation_confirmed.html**
Added text informing the user that payment will be done on-site. The text is only displayed if the orders payment method is `'cash'`.
