### PR TITLE
modified varaamo-templates to show universal_data values 

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -141,6 +141,14 @@ function generateTemplates(cb, lang = 'FI', files = [], service = 'varaamo') {
                 removeTags: true,
                 quiet: true,
             }))
+            .pipe(inject(gulp.src('./pages/template/universal_field.html'), { // inject universal-field html
+                starttag:  '<!-- inject:universal-field:html -->',
+                transform: function (filePath, file) {
+                    return file.contents.toString('utf8')
+                },
+                removeTags: true,
+                quiet: true,
+            }))
             .pipe(replace(MAP_URLS.SERVICE_MAP.SRC, MAP_URLS.SERVICE_MAP[lang])) // replace map url placeholder
             .pipe(inlineCss({
                 url: 'file://' + __dirname + '/pages/template/', // specifies the base path for the stylesheet links

--- a/pages/template/universal_field.html
+++ b/pages/template/universal_field.html
@@ -1,0 +1,3 @@
+{% if universal_data.label is defined and universal_data.selected_value is defined %}
+    <p>{{ universal_data.label }}: {{ universal_data.selected_value }}</p>
+{% endif %}

--- a/pages/varaamo/en/en-reservation_cancelled.html
+++ b/pages/varaamo/en/en-reservation_cancelled.html
@@ -21,4 +21,8 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <p>Best regards, Varaamo</p>

--- a/pages/varaamo/en/en-reservation_cancelled_by_official_client.html
+++ b/pages/varaamo/en/en-reservation_cancelled_by_official_client.html
@@ -20,6 +20,10 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>

--- a/pages/varaamo/en/en-reservation_cancelled_official.html
+++ b/pages/varaamo/en/en-reservation_cancelled_official.html
@@ -25,6 +25,10 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if extra_content is defined and extra_content %}
 {{ extra_content }}
 {% endif %}

--- a/pages/varaamo/en/en-reservation_confirmed.html
+++ b/pages/varaamo/en/en-reservation_confirmed.html
@@ -10,6 +10,10 @@
 <p>Unit: {{ unit }}</p>
 <p>Start: {{ begin }}</p>
 <p>End: {{ end }}</p>
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <p></p>
 {% if order is defined %}
 <hr />

--- a/pages/varaamo/en/en-reservation_created.html
+++ b/pages/varaamo/en/en-reservation_created.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>

--- a/pages/varaamo/en/en-reservation_created_by_official_client.html
+++ b/pages/varaamo/en/en-reservation_created_by_official_client.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>

--- a/pages/varaamo/en/en-reservation_created_official.html
+++ b/pages/varaamo/en/en-reservation_created_official.html
@@ -25,6 +25,10 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if require_assistance is defined and require_assistance %}
     <p>Reserver needs assistance.</p>
 {% endif %}

--- a/pages/varaamo/en/en-reservation_modified.html
+++ b/pages/varaamo/en/en-reservation_modified.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>

--- a/pages/varaamo/en/en-reservation_modified_by_official_client.html
+++ b/pages/varaamo/en/en-reservation_modified_by_official_client.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>

--- a/pages/varaamo/en/en-reservation_modified_official.html
+++ b/pages/varaamo/en/en-reservation_modified_official.html
@@ -26,6 +26,10 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if extra_question is defined and extra_question %}
     <p>Additional question: {{ extra_question }}</p>
 {% endif %}

--- a/pages/varaamo/en/en-reservation_requested.html
+++ b/pages/varaamo/en/en-reservation_requested.html
@@ -28,6 +28,10 @@
 {% if number_of_participants is defined %}
 <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/en/en-reservation_requested_by_official.html
+++ b/pages/varaamo/en/en-reservation_requested_by_official.html
@@ -28,6 +28,10 @@
 {% if number_of_participants is defined %}
 <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/en/en-reservation_requested_official.html
+++ b/pages/varaamo/en/en-reservation_requested_official.html
@@ -27,6 +27,10 @@
 {% if number_of_participants is defined %}
 <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/fi/fi-reservation_cancelled.html
+++ b/pages/varaamo/fi/fi-reservation_cancelled.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <p>Tervetuloa asioimaan uudelleen!</p>
 <p>Ystävällisin terveisin, Varaamo</p>
 

--- a/pages/varaamo/fi/fi-reservation_cancelled_by_official_client.html
+++ b/pages/varaamo/fi/fi-reservation_cancelled_by_official_client.html
@@ -20,6 +20,10 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>

--- a/pages/varaamo/fi/fi-reservation_cancelled_official.html
+++ b/pages/varaamo/fi/fi-reservation_cancelled_official.html
@@ -22,6 +22,10 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if extra_content is defined and extra_content %}
 {{ extra_content }}
 {% endif %}

--- a/pages/varaamo/fi/fi-reservation_confirmed.html
+++ b/pages/varaamo/fi/fi-reservation_confirmed.html
@@ -10,6 +10,10 @@
 <p>Toimipiste: {{ unit }}</p>
 <p>Alkaa: {{ begin }}</p>
 <p>Loppuu: {{ end }}</p>
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <p></p>
 {% if order is defined %}
 <hr />

--- a/pages/varaamo/fi/fi-reservation_created.html
+++ b/pages/varaamo/fi/fi-reservation_created.html
@@ -24,6 +24,10 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>

--- a/pages/varaamo/fi/fi-reservation_created_by_official_client.html
+++ b/pages/varaamo/fi/fi-reservation_created_by_official_client.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>

--- a/pages/varaamo/fi/fi-reservation_created_official.html
+++ b/pages/varaamo/fi/fi-reservation_created_official.html
@@ -25,6 +25,10 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if require_assistance is defined and require_assistance %}
     <p>Varaaja tarvitsee opastusta.</p>
 {% endif %}

--- a/pages/varaamo/fi/fi-reservation_modified.html
+++ b/pages/varaamo/fi/fi-reservation_modified.html
@@ -20,6 +20,10 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>

--- a/pages/varaamo/fi/fi-reservation_modified_by_official_client.html
+++ b/pages/varaamo/fi/fi-reservation_modified_by_official_client.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>

--- a/pages/varaamo/fi/fi-reservation_modified_official.html
+++ b/pages/varaamo/fi/fi-reservation_modified_official.html
@@ -26,6 +26,10 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if extra_question is defined and extra_question %}
     <p>Lisäkysymys: {{ extra_question }}</p>
 {% endif %}

--- a/pages/varaamo/fi/fi-reservation_requested.html
+++ b/pages/varaamo/fi/fi-reservation_requested.html
@@ -28,6 +28,10 @@
 {% if number_of_participants is defined %}
 <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/fi/fi-reservation_requested_by_official.html
+++ b/pages/varaamo/fi/fi-reservation_requested_by_official.html
@@ -28,6 +28,10 @@
 {% if number_of_participants is defined %}
 <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/fi/fi-reservation_requested_official.html
+++ b/pages/varaamo/fi/fi-reservation_requested_official.html
@@ -27,6 +27,10 @@
 {% if number_of_participants is defined %}
 <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/sv/sv-reservation_cancelled.html
+++ b/pages/varaamo/sv/sv-reservation_cancelled.html
@@ -21,5 +21,9 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <p>Välkommen åter!</p>
 <p>Med vänliga hälsningar, Varaamo</p>

--- a/pages/varaamo/sv/sv-reservation_cancelled_by_official_client.html
+++ b/pages/varaamo/sv/sv-reservation_cancelled_by_official_client.html
@@ -20,6 +20,10 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>

--- a/pages/varaamo/sv/sv-reservation_cancelled_official.html
+++ b/pages/varaamo/sv/sv-reservation_cancelled_official.html
@@ -25,6 +25,10 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if extra_content is defined and extra_content %}
 {{ extra_content }}
 {% endif %}

--- a/pages/varaamo/sv/sv-reservation_confirmed.html
+++ b/pages/varaamo/sv/sv-reservation_confirmed.html
@@ -10,6 +10,10 @@
 <p>Plats: {{ unit }}</p>
 <p>Börjar: {{ begin }}</p>
 <p>Slutar: {{ end }}</p>
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <p></p>
 {% if order is defined %}
 <hr />

--- a/pages/varaamo/sv/sv-reservation_created.html
+++ b/pages/varaamo/sv/sv-reservation_created.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>

--- a/pages/varaamo/sv/sv-reservation_created_by_official_client.html
+++ b/pages/varaamo/sv/sv-reservation_created_by_official_client.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>

--- a/pages/varaamo/sv/sv-reservation_created_official.html
+++ b/pages/varaamo/sv/sv-reservation_created_official.html
@@ -25,6 +25,10 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if require_assistance is defined and require_assistance %}
     <p>Bokaren behöver instruering.</p>
 {% endif %}

--- a/pages/varaamo/sv/sv-reservation_modified.html
+++ b/pages/varaamo/sv/sv-reservation_modified.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>

--- a/pages/varaamo/sv/sv-reservation_modified_by_official_client.html
+++ b/pages/varaamo/sv/sv-reservation_modified_by_official_client.html
@@ -21,6 +21,10 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>

--- a/pages/varaamo/sv/sv-reservation_modified_official.html
+++ b/pages/varaamo/sv/sv-reservation_modified_official.html
@@ -26,6 +26,10 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 {% if require_assistance %}
     <p>Bokaren behöver instruering.</p>
 {% endif %}

--- a/pages/varaamo/sv/sv-reservation_requested.html
+++ b/pages/varaamo/sv/sv-reservation_requested.html
@@ -28,6 +28,10 @@
 {% if number_of_participants is defined %}
 <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/sv/sv-reservation_requested_by_official.html
+++ b/pages/varaamo/sv/sv-reservation_requested_by_official.html
@@ -28,6 +28,10 @@
 {% if number_of_participants is defined %}
 <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}

--- a/pages/varaamo/sv/sv-reservation_requested_official.html
+++ b/pages/varaamo/sv/sv-reservation_requested_official.html
@@ -27,6 +27,10 @@
 {% if number_of_participants is defined %}
 <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
+{% if universal_data is defined and universal_data %}
+<!--inject:universal-field:html-->
+<!-- endinject -->
+{% endif %}
 <hr />
 {% if extra_content is defined %}
 {{ extra_content }}


### PR DESCRIPTION
# Modified varaamo-templates to show universal_data values if they exist


#### Updated varaamo-templates to show universal_data values if they exist. A Reservation has universal_data values if the resource had a universal-field when the reservation was made.

-----------------------------------------------------------------------------------------------
Changes:

- **gulpfile.babel.js**:
Added new .pipe section that injects the `universal_field.html` template into other templates.

- **pages/template/universal_field.html**:
New template for displaying `universal_data` values. This is a separate template that is injected into the other templates. 

- **pages/varaamo/en/*.html**:
Added universal-field inject tag to templates.

- **pages/varaamo/fi/*.html**:
Added universal-field inject tag to templates.

- **pages/varaamo/sv/*.html**:
Added universal-field inject tag to templates.