### PR TITLE
Removed additional info rows

### DIFF
--- a/pages/varaamo/en/en-reservation_created.html
+++ b/pages/varaamo/en/en-reservation_created.html
@@ -25,9 +25,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>

--- a/pages/varaamo/en/en-reservation_created_by_official_client.html
+++ b/pages/varaamo/en/en-reservation_created_by_official_client.html
@@ -25,9 +25,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>

--- a/pages/varaamo/en/en-reservation_modified.html
+++ b/pages/varaamo/en/en-reservation_modified.html
@@ -25,9 +25,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>

--- a/pages/varaamo/en/en-reservation_modified_by_official_client.html
+++ b/pages/varaamo/en/en-reservation_modified_by_official_client.html
@@ -25,9 +25,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>

--- a/pages/varaamo/fi/fi-reservation_created.html
+++ b/pages/varaamo/fi/fi-reservation_created.html
@@ -28,9 +28,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>

--- a/pages/varaamo/fi/fi-reservation_created_by_official_client.html
+++ b/pages/varaamo/fi/fi-reservation_created_by_official_client.html
@@ -25,9 +25,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>

--- a/pages/varaamo/fi/fi-reservation_modified.html
+++ b/pages/varaamo/fi/fi-reservation_modified.html
@@ -24,9 +24,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>

--- a/pages/varaamo/fi/fi-reservation_modified_by_official_client.html
+++ b/pages/varaamo/fi/fi-reservation_modified_by_official_client.html
@@ -25,9 +25,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>

--- a/pages/varaamo/sv/sv-reservation_created.html
+++ b/pages/varaamo/sv/sv-reservation_created.html
@@ -25,9 +25,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>

--- a/pages/varaamo/sv/sv-reservation_created_by_official_client.html
+++ b/pages/varaamo/sv/sv-reservation_created_by_official_client.html
@@ -25,9 +25,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>

--- a/pages/varaamo/sv/sv-reservation_modified.html
+++ b/pages/varaamo/sv/sv-reservation_modified.html
@@ -25,9 +25,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>

--- a/pages/varaamo/sv/sv-reservation_modified_by_official_client.html
+++ b/pages/varaamo/sv/sv-reservation_modified_by_official_client.html
@@ -25,9 +25,6 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if additional_information is defined %}
-    <p>{{ additional_information }}</p>
-{% endif %}
 {% if unit is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>


### PR DESCRIPTION
# Removal of additional information rows from email templates

Additional information can't be used as general instruction/contact info in email templates because it serves as a help text for extra question fields.