### PR TITLE
Changed condition when service map link is rendered

### DIFF
--- a/pages/monitori/en/en-reservation_created.html
+++ b/pages/monitori/en/en-reservation_created.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}

--- a/pages/monitori/en/en-reservation_created_by_official.html
+++ b/pages/monitori/en/en-reservation_created_by_official.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}

--- a/pages/monitori/en/en-reservation_modified.html
+++ b/pages/monitori/en/en-reservation_modified.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}

--- a/pages/monitori/en/en-reservation_modified_by_official.html
+++ b/pages/monitori/en/en-reservation_modified_by_official.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}

--- a/pages/monitori/fi/fi-reservation_created.html
+++ b/pages/monitori/fi/fi-reservation_created.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}

--- a/pages/monitori/fi/fi-reservation_created_by_official.html
+++ b/pages/monitori/fi/fi-reservation_created_by_official.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}

--- a/pages/monitori/fi/fi-reservation_modified.html
+++ b/pages/monitori/fi/fi-reservation_modified.html
@@ -20,7 +20,7 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}

--- a/pages/monitori/fi/fi-reservation_modified_by_official.html
+++ b/pages/monitori/fi/fi-reservation_modified_by_official.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}

--- a/pages/monitori/sv/sv-reservation_created.html
+++ b/pages/monitori/sv/sv-reservation_created.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}

--- a/pages/monitori/sv/sv-reservation_created_by_official.html
+++ b/pages/monitori/sv/sv-reservation_created_by_official.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}

--- a/pages/monitori/sv/sv-reservation_modified.html
+++ b/pages/monitori/sv/sv-reservation_modified.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}

--- a/pages/monitori/sv/sv-reservation_modified_by_official.html
+++ b/pages/monitori/sv/sv-reservation_modified_by_official.html
@@ -21,7 +21,7 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}

--- a/pages/varaamo/en/en-recurring_reservation_created.html
+++ b/pages/varaamo/en/en-recurring_reservation_created.html
@@ -25,7 +25,7 @@
 {% if number_of_participants is defined %}
     <p>Number of participants: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}

--- a/pages/varaamo/en/en-reservation_cancelled_by_official.html
+++ b/pages/varaamo/en/en-reservation_cancelled_by_official.html
@@ -24,7 +24,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}

--- a/pages/varaamo/en/en-reservation_created.html
+++ b/pages/varaamo/en/en-reservation_created.html
@@ -25,7 +25,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}

--- a/pages/varaamo/en/en-reservation_created_by_official.html
+++ b/pages/varaamo/en/en-reservation_created_by_official.html
@@ -25,7 +25,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}

--- a/pages/varaamo/en/en-reservation_modified.html
+++ b/pages/varaamo/en/en-reservation_modified.html
@@ -25,7 +25,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}

--- a/pages/varaamo/en/en-reservation_modified_by_official.html
+++ b/pages/varaamo/en/en-reservation_modified_by_official.html
@@ -25,7 +25,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Show location on the servicemap</a>
 {% endif %}

--- a/pages/varaamo/fi/fi-recurring_reservation_created.html
+++ b/pages/varaamo/fi/fi-recurring_reservation_created.html
@@ -28,7 +28,7 @@
 {% if number_of_participants is defined %}
     <p>Osallistujamäärä: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}

--- a/pages/varaamo/fi/fi-reservation_cancelled_by_official.html
+++ b/pages/varaamo/fi/fi-reservation_cancelled_by_official.html
@@ -24,7 +24,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}

--- a/pages/varaamo/fi/fi-reservation_created.html
+++ b/pages/varaamo/fi/fi-reservation_created.html
@@ -28,7 +28,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}

--- a/pages/varaamo/fi/fi-reservation_created_by_official.html
+++ b/pages/varaamo/fi/fi-reservation_created_by_official.html
@@ -25,7 +25,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}

--- a/pages/varaamo/fi/fi-reservation_modified.html
+++ b/pages/varaamo/fi/fi-reservation_modified.html
@@ -24,7 +24,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}

--- a/pages/varaamo/fi/fi-reservation_modified_by_official.html
+++ b/pages/varaamo/fi/fi-reservation_modified_by_official.html
@@ -25,7 +25,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Näytä sijainti palvelukartalla</a>
 {% endif %}

--- a/pages/varaamo/sv/sv-recurring_reservation_created.html
+++ b/pages/varaamo/sv/sv-recurring_reservation_created.html
@@ -28,7 +28,7 @@
 {% if number_of_participants is defined %}
     <p>Antal deltagare: {{ number_of_participants }}</p>
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}

--- a/pages/varaamo/sv/sv-reservation_cancelled_by_official.html
+++ b/pages/varaamo/sv/sv-reservation_cancelled_by_official.html
@@ -24,7 +24,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}

--- a/pages/varaamo/sv/sv-reservation_created.html
+++ b/pages/varaamo/sv/sv-reservation_created.html
@@ -25,7 +25,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}

--- a/pages/varaamo/sv/sv-reservation_created_by_official.html
+++ b/pages/varaamo/sv/sv-reservation_created_by_official.html
@@ -25,7 +25,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}

--- a/pages/varaamo/sv/sv-reservation_modified.html
+++ b/pages/varaamo/sv/sv-reservation_modified.html
@@ -25,7 +25,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}

--- a/pages/varaamo/sv/sv-reservation_modified_by_official.html
+++ b/pages/varaamo/sv/sv-reservation_modified_by_official.html
@@ -25,7 +25,7 @@
 <!--inject:universal-field:html-->
 <!-- endinject -->
 {% endif %}
-{% if unit is defined %}
+{% if unit_map_service_id is defined %}
 {% set linkUrl = '<--map_url-->' + unit_map_service_id|string + '#' %}
     <a href="{{ linkUrl }}">Visa på servicekartan</a>
 {% endif %}


### PR DESCRIPTION
Service map link will be rendered only when its related `unit_map_service_id` exists instead of only checking whether unit exists.

[Related Trello card](https://trello.com/c/p83zGDil)